### PR TITLE
Remove gemfile require

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ### Gemfile
-`gem 'activeagent', require: 'active_agent'`
+`gem 'activeagent'`
 
 ### CLI
 `gem install activeagent`

--- a/lib/activeagent.rb
+++ b/lib/activeagent.rb
@@ -1,0 +1,1 @@
+require "active_agent"


### PR DESCRIPTION
This fixes the issue of requiring the gem from the gemfile. It solves this problem by creating a main file that matches the gem name and then requiring the real main file from there. This may not be ideal.

I tried to find a way to solve this without adding the new main file, but I didn't figure it out. I think there should be a way because other gems do this, like `activesupport`.