### PR TITLE
Add require active_agent to initializer

### DIFF
--- a/lib/generators/active_agent/templates/initializer.rb
+++ b/lib/generators/active_agent/templates/initializer.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+require 'active_agent'
+
 ActiveAgent.load_configuration(Rails.root.join('config', 'active_agent.yml'))


### PR DESCRIPTION
When following the instructions on the README, running

`bin/rails generate active_agent:agent travel search book plans`

Results in

```
config/initializers/active_agent.rb:3:in '<main>': uninitialized constant ActiveAgent (NameError)

ActiveAgent.load_configuration(Rails.root.join('config', 'active_agent.yml'))
^^^^^^^^^^^
Did you mean?  ActiveStorage
```

This change adds `require 'active_agent'` to the initializer template so `ActiveAgent` is available in the initializer
