### PR TITLE
Fix broken generators

### DIFF
--- a/lib/generators/active_agent/templates/agent.html.erb
+++ b/lib/generators/active_agent/templates/agent.html.erb
@@ -1,1 +1,1 @@
-<%= yield %>
+<%= yield if block_given? %>

--- a/lib/generators/active_agent/templates/agent.text.erb
+++ b/lib/generators/active_agent/templates/agent.text.erb
@@ -1,1 +1,1 @@
-<%= yield %>
+<%= yield if block_given? %>


### PR DESCRIPTION
I've tried to include this project in a fresh Ruby 8.0 app and it looks like the generators didn't work for me.

When running `rails generate active_agent:install` I've got:

```
/Users/kris/Projects/activeagent/lib/generators/active_agent/templates/agent.html.erb:1:in `template': no block given (yield) (LocalJumpError)
```

It looks like the generators aren't passing blocks to those templates, so perhaps there should be a guard for this case? Or am I using it wrong?