### PR TITLE
Add OpenRouter support

### DIFF
--- a/lib/active_agent/generation_provider/open_router_provider.rb
+++ b/lib/active_agent/generation_provider/open_router_provider.rb
@@ -1,0 +1,17 @@
+# lib/active_agent/generation_provider/openrouter_provider.rb
+
+require "openai"
+require_relative "open_ai_provider"
+
+module ActiveAgent
+  module GenerationProvider
+    class OpenRouterProvider < OpenAIProvider
+      def initialize(config)
+        @config = config
+        @api_key = config["api_key"]
+        @model_name = config["model"]
+        @client = OpenAI::Client.new(uri_base: "https://openrouter.ai/api/v1", access_token: @api_key, log_errors: true)
+      end
+    end
+  end
+end

--- a/lib/active_agent/generation_provider/open_router_provider.rb
+++ b/lib/active_agent/generation_provider/open_router_provider.rb
@@ -1,5 +1,3 @@
-# lib/active_agent/generation_provider/openrouter_provider.rb
-
 require "openai"
 require_relative "open_ai_provider"
 


### PR DESCRIPTION
This adds OpenRouter support. OpenRouter mirrors OpenAI's API, although they do not currently support embedding models.