### PR TITLE
feat: support YAML aliases in configuration

### DIFF
--- a/lib/active_agent.rb
+++ b/lib/active_agent.rb
@@ -49,7 +49,7 @@ module ActiveAgent
 
     def load_configuration(file)
       if File.exist?(file)
-        config_file = YAML.load(ERB.new(File.read(file)).result)
+        config_file = YAML.load(ERB.new(File.read(file)).result, aliases: true)
         env = ENV["RAILS_ENV"] || ENV["ENV"] || "development"
         @config = config_file[env] || config_file
       end


### PR DESCRIPTION
So I can write my config as follows:

```yml
default_gpt: &default_gpt
  service: open_ai
  model: "gpt-4o-mini"
  temperature: 0.5
  api_key: <%= Rails.application.credentials.openai&.api_key %>

development:
  gpt:
    <<: *default_gpt

production:
  gpt:
    <<: *default_gpt

test:
  gpt:
    service: fake_llm
```