### PR TITLE
fix: updated auth for openai

### DIFF
--- a/lib/active_agent/generation_provider/open_ai_provider.rb
+++ b/lib/active_agent/generation_provider/open_ai_provider.rb
@@ -10,7 +10,7 @@ module ActiveAgent
         super
         @api_key = config["api_key"]
         @model_name = config["model"] || "gpt-4o-mini"
-        @client = OpenAI::Client.new(access_token: @api_key, log_errors: true)
+        @client = OpenAI::Client.new(api_key: @api_key)
       end
 
       def generate(prompt)


### PR DESCRIPTION
Was getting the following error:

```
...gems/openai-0.4.1/lib/openai/client.rb:105:in `initialize': unknown keywords: :access_token, :log_errors (ArgumentError)
```

The openai gem (specifically the official supported by openai `gem "openai", "~> 0.4.1"`) uses `api_key` now and doesn't have that log_errors option.  This PR reflects that change.