### PR TITLE
Adjust PLATFORMS in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     zeitwerk (2.7.2)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
When `bundle install` is run on a different macOS version, it will add a new entry to `PLATFORMS` for each release, e.g. `arm64-darwin-24` in my case. If we remove the numeric suffix, then it will work with any version.