### PR TITLE
Prevent warning in InstallGeneratorTest

### DIFF
--- a/test/generators/test_unit/install_generator_test.rb
+++ b/test/generators/test_unit/install_generator_test.rb
@@ -7,7 +7,7 @@ class TestUnit::Generators::InstallGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
 
   test "runs without error" do
-    run_generator
+    run_generator [ "user" ]
 
     # Currently no files are created by the TestUnit install generator
     # This test ensures it runs without error


### PR DESCRIPTION
Prevent `No value provided for required arguments 'name'` from being emitted, as shown [here](https://github.com/activeagents/activeagent/actions/runs/15854564279/job/44696482927).