### PR TITLE
Update generator USAGE with full generator name

### DIFF
--- a/lib/generators/active_agent/USAGE
+++ b/lib/generators/active_agent/USAGE
@@ -6,13 +6,13 @@ Description:
     engine and test framework generators.
 
 Examples:
-    `bin/rails generate agent inventory search`
+    `bin/rails generate active_agent:agent inventory search`
 
     creates a sign up mailer class, views, and test:
         Agent:     app/agents/inventory_agent.rb
         Views:      app/views/inventory_agent/search.text.erb [...]
         Test:       test/agents/inventory_agent_test.rb
 
-    `bin/rails generate agent inventory search update report`
+    `bin/rails generate active_agent:agent inventory search update report`
 
     creates an inventory agent with search, update, and report actions.


### PR DESCRIPTION
Running the command before the change in a simple Rails app leads to:

```sh
% bin/rails generate agent inventory search                                                                                                                                                                                    
Could not find generator 'agent'. (Rails::Command::CorrectableNameError)
```

With the updated command:

```rb
% bin/rails generate active_agent:agent inventory search                                                                                                                                                                       
      create  app/agents/inventory_agent.rb
      create  app/agents/application_agent.rb
      invoke  erb
      create    app/views/inventory_agent
      create    app/views/inventory_agent/search.text.erb
      create    app/views/inventory_agent/search.html.erb
      invoke  test_unit
      create    test/agents/inventory_agent_test.rb
      create    test/agents/previews/inventory_agent_preview.rb
```