### PR TITLE
Allow to use templates for instructions

### DIFF
--- a/docs/docs/action-prompt/actions.md
+++ b/docs/docs/action-prompt/actions.md
@@ -18,6 +18,38 @@ You can define actions in your agent class that can be used to interact with the
 :::
 
 
+
+## Set up instructions
+
+You can configure instructions in several ways when using `generate_with`. Here are the supported options:
+
+#### 1. Use the default instructions template
+If you don’t pass anything for instructions, it will automatically try to use the default instructions template: `instructions.text.erb`
+
+::: code-group
+<<< @/../test/dummy/app/agents/scoped_agents/translation_agent_with_default_instructions_template.rb{ruby:line-numbers} [translation_agent_with_default_instructions_template.rb]
+<<< @/../test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/instructions.text.erb{erb:line-numbers} [instructions.text.erb]
+:::
+
+#### 2. Use a custom instructions template (global or per action)
+You can provide custom instructions using a template. This can be done in two ways:
+  * **Globally**, by setting an instructions template for the whole agent.
+  * **Per action**, by specifying a different template for a specific prompt call.
+To do this, pass a `Hash` with a `template` key to the `instructions` option:
+
+::: code-group
+<<< @/../test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb{ruby:line-numbers} [translation_agent_with_custom_instructions_template.rb]
+<<< @/../test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/custom_instructions.text.erb{erb:line-numbers} [custom_instructions.text.erb]
+<<< @/../test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/overridden_instructions.text.erb{erb:line-numbers} [overridden_instructions.text.erb]
+:::
+
+#### 3. Use plain text instructions
+You can also directly pass a string of instructions
+
+::: code-group
+<<< @/../test/dummy/app/agents/translation_agent.rb{ruby:line-numbers} [translation_agent.rb]
+:::
+
 ## Call to Actions
 These actions can be invoked by the agent to perform specific tasks and receive the results or in your Rails app's controllers, models, or jobs to prompt the agent for generation with a templated prompt message. By default, public instance methods defined in the agent class are included in the context as available actions. You can also define actions in a separate concern module and include them in your agent class.
 
@@ -52,17 +84,20 @@ The `prompt` takes the following options:
 - `message`: The `message.content` to be displayed in the prompt.
 - `messages`: An array of messages objects to be included in the prompt's context.
 - `template_name`: Specifies the name of the template to be used for rendering the action's response.
+- `instructions`: Additional guidance for the prompt generation. This can be:
+  * A string with custom instructions (e.g., "Help the user find a hotel");
+  * A hash referencing a template (e.g., { template: :custom_template });
 
 ```ruby [app/agents/travel_agent.rb]
 class TravelAgent < ActiveAgent::Agent
   def search
     Place.search(params[:location])
-    prompt(content_type: :text, template_name: 'search_results')
+    prompt(content_type: :text, template_name: 'search_results', instructions: 'Help the user find a hotel')
   end
 
   def book
     Place.book(hotel_id: params[:hotel_id], user_id: params[:user_id])
-    prompt(content_type: :json, template_name: 'booking_confirmation')
+    prompt(content_type: :json, template_name: 'booking_confirmation', instructions: { template: 'book_instructions' })
   end
 
   def confirm

--- a/test/action_prompt/prompt_test.rb
+++ b/test/action_prompt/prompt_test.rb
@@ -54,7 +54,7 @@ module ActiveAgent
         assert_equal attributes[:body], prompt.body
         assert_equal attributes[:content_type], prompt.content_type
         assert_equal attributes[:message], prompt.message.content
-        assert_equal ([ Message.new(content: "Test instructions", role: :system) ] + attributes[:messages]).map(&:to_h), prompt.messages.map(&:to_h)
+        assert_equal ([ Message.new(content: "Test instructions", role: :system) ] + attributes[:messages] + [ Message.new(content: attributes[:message], role: :user) ]).map(&:to_h), prompt.messages.map(&:to_h)
         assert_equal attributes[:params], prompt.params
         assert_equal attributes[:mime_version], prompt.mime_version
         assert_equal attributes[:charset], prompt.charset

--- a/test/agents/scoped_agents/translation_agent_with_custom_instructions_template_test.rb
+++ b/test/agents/scoped_agents/translation_agent_with_custom_instructions_template_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class ScopedAgents::TranslationAgentWithCustomInstructionsTemplateTest < ActiveSupport::TestCase
+  test "it uses instructions from custom_instructions template" do
+    translate_prompt = ScopedAgents::TranslationAgentWithCustomInstructionsTemplate.with(
+      message: "Hi, I'm Justin", locale: "japanese"
+    ).translate
+
+    assert_equal "# Custom Instructions\n\nTranslate the given text from English to French.\n", translate_prompt.instructions
+  end
+
+  test "it uses overridden instructions for prompt" do
+    translate_prompt = ScopedAgents::TranslationAgentWithCustomInstructionsTemplate.with(
+      message: "Hi, I'm Justin", locale: "japanese"
+    ).translate_with_overridden_instructions
+
+    assert_equal "# Overridden Instructions\n\nTranslate the given text from one language to another.\n", translate_prompt.instructions
+  end
+end

--- a/test/agents/scoped_agents/translation_agent_with_default_instructions_template_test.rb
+++ b/test/agents/scoped_agents/translation_agent_with_default_instructions_template_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class ScopedAgents::TranslationAgentWithDefaultInstructionsTemplateTest < ActiveSupport::TestCase
+  test "it uses instructions from default instructions template" do
+    translate_prompt = ScopedAgents::TranslationAgentWithDefaultInstructionsTemplate.with(
+      message: "Hi, I'm Justin", locale: "japanese"
+    ).translate
+
+    assert_equal "# Default Instructions\n\nTranslate the given text from one language to another.\n", translate_prompt.instructions
+  end
+end

--- a/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
+++ b/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
@@ -1,0 +1,15 @@
+module ScopedAgents
+  class TranslationAgentWithCustomInstructionsTemplate < ApplicationAgent
+    generate_with :openai, instructions: {
+      template: :custom_instructions, locals: { from: "English", to: "French" }
+    }
+
+    def translate
+      prompt
+    end
+
+    def translate_with_overridden_instructions
+      prompt(instructions: { template: :overridden_instructions })
+    end
+  end
+end

--- a/test/dummy/app/agents/scoped_agents/translation_agent_with_default_instructions_template.rb
+++ b/test/dummy/app/agents/scoped_agents/translation_agent_with_default_instructions_template.rb
@@ -1,0 +1,9 @@
+module ScopedAgents
+  class TranslationAgentWithDefaultInstructionsTemplate < ApplicationAgent
+    generate_with :openai
+
+    def translate
+      prompt
+    end
+  end
+end

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/custom_instructions.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/custom_instructions.text.erb
@@ -1,0 +1,3 @@
+# Custom Instructions
+
+Translate the given text from <%= from %> to <%= to %>.

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/overridden_instructions.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/overridden_instructions.text.erb
@@ -1,0 +1,3 @@
+# Overridden Instructions
+
+Translate the given text from one language to another.

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate.json.jbuilder
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate.json.jbuilder
@@ -1,0 +1,14 @@
+json.type :function
+json.function do
+  json.name action_name
+  json.description "This action accepts a 'message' parameter in English and returns its translation in French."
+  json.parameters do
+    json.type :object
+    json.properties do
+      json.message do
+        json.type :string
+        json.description "The text to be translated."
+      end
+    end
+  end
+end

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate.text.erb
@@ -1,0 +1,1 @@
+translate: <%= params[:message] %>; to French

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate_with_overridden_instructions.json.jbuilder
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate_with_overridden_instructions.json.jbuilder
@@ -1,0 +1,18 @@
+json.type :function
+json.function do
+  json.name action_name
+  json.description "This action takes params locale and message and returns a translated message."
+  json.parameters do
+    json.type :object
+    json.properties do
+      json.locale do
+        json.type :string
+        json.description "The target language for translation."
+      end
+      json.message do
+        json.type :string
+        json.description "The text to be translated."
+      end
+    end
+  end
+end

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate_with_overridden_instructions.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/translate_with_overridden_instructions.text.erb
@@ -1,0 +1,1 @@
+translate: <%= params[:message] %>; to <%= params[:locale] %>

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/instructions.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/instructions.text.erb
@@ -1,0 +1,3 @@
+# Default Instructions
+
+Translate the given text from one language to another.

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/translate.json.jbuilder
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/translate.json.jbuilder
@@ -1,0 +1,18 @@
+json.type :function
+json.function do
+  json.name action_name
+  json.description "This action takes params locale and message and returns a translated message."
+  json.parameters do
+    json.type :object
+    json.properties do
+      json.locale do
+        json.type :string
+        json.description "The target language for translation."
+      end
+      json.message do
+        json.type :string
+        json.description "The text to be translated."
+      end
+    end
+  end
+end

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/translate.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/translate.text.erb
@@ -1,0 +1,1 @@
+translate: <%= params[:message] %>; to <%= params[:locale] %>


### PR DESCRIPTION
I’ve added support for templates in the instructions, but decided to more explicitly separate the behavior when we expect a plain string (`instructions: "Plain string"`) and when it’s a template (`instructions: { template: "instructions_template" }`). It seems that this approach gives us more clarity, doesn’t it?
Additionally, we could pass locales into the template, which likely expands our capabilities.

Closes https://github.com/activeagents/activeagent/issues/82