### PR TITLE
lazy instructions generation

### DIFF
--- a/lib/active_agent/action_prompt/base.rb
+++ b/lib/active_agent/action_prompt/base.rb
@@ -239,9 +239,7 @@ module ActiveAgent
       def initialize
         super
         @_prompt_was_called = false
-        @_context = ActiveAgent::ActionPrompt::Prompt.new(
-          instructions: prepare_instructions(options[:instructions]), options: options
-        )
+        @_context = ActiveAgent::ActionPrompt::Prompt.new(options: options)
       end
 
       def process(method_name, *args) # :nodoc:
@@ -296,7 +294,8 @@ module ActiveAgent
       def prompt(headers = {}, &block)
         return context if @_prompt_was_called && headers.blank? && !block
 
-        context.instructions = prepare_instructions(headers[:instructions]) if headers.has_key?(:instructions)
+        raw_instructions = headers.has_key?(:instructions) ? headers[:instructions] : context.options[:instructions]
+        context.instructions = prepare_instructions(raw_instructions)
         context.options.merge!(options)
         content_type = headers[:content_type]
         headers = apply_defaults(headers)

--- a/lib/active_agent/action_prompt/prompt.rb
+++ b/lib/active_agent/action_prompt/prompt.rb
@@ -34,6 +34,8 @@ module ActiveAgent
       end
 
       def instructions=(instructions)
+        return if instructions.blank?
+
         @instructions = instructions
         if @messages[0].present? && @messages[0].role == :system
           @messages[0] = instructions_message

--- a/test/action_prompt/prompt_test.rb
+++ b/test/action_prompt/prompt_test.rb
@@ -172,6 +172,28 @@ module ActiveAgent
         assert_equal :user, prompt.message.role
       end
 
+      test "instructions setter adds instruction to messages" do
+        prompt = Prompt.new
+        prompt.instructions = "System instructions"
+        assert_equal 1, prompt.messages.size
+        assert_equal "System instructions", prompt.messages.first.content
+        assert_equal :system, prompt.messages.first.role
+      end
+
+      test "instructions setter replace instruction if it already exists in messages" do
+        prompt = Prompt.new(instructions: "System instructions")
+        prompt.instructions = "New system instructions"
+        assert_equal 1, prompt.messages.size
+        assert_equal "New system instructions", prompt.messages.first.content
+        assert_equal :system, prompt.messages.first.role
+      end
+
+      test "instructions setter does not add empty instruction to messages" do
+        prompt = Prompt.new
+        prompt.instructions = ""
+        assert_equal 0, prompt.messages.size
+      end
+
       test "initializes with actions, message, and messages example" do
         # region support_agent_prompt_initialization
         prompt = ActiveAgent::ActionPrompt::Prompt.new(

--- a/test/agents/scoped_agents/translation_agent_with_custom_instructions_template_test.rb
+++ b/test/agents/scoped_agents/translation_agent_with_custom_instructions_template_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
 class ScopedAgents::TranslationAgentWithCustomInstructionsTemplateTest < ActiveSupport::TestCase
-  test "it uses instructions from custom_instructions template" do
+  test "it uses instructions from custom_instructions template, embedding locales and an instance variable" do
     translate_prompt = ScopedAgents::TranslationAgentWithCustomInstructionsTemplate.with(
       message: "Hi, I'm Justin", locale: "japanese"
     ).translate
 
-    assert_equal "# Custom Instructions\n\nTranslate the given text from English to French.\n", translate_prompt.instructions
+    assert_equal "# Custom Instructions\n\ntranslation additional instruction\nTranslate the given text from English to French.\n", translate_prompt.instructions
   end
 
   test "it uses overridden instructions for prompt" do

--- a/test/agents/scoped_agents/translation_agent_with_default_instructions_template_test.rb
+++ b/test/agents/scoped_agents/translation_agent_with_default_instructions_template_test.rb
@@ -8,4 +8,12 @@ class ScopedAgents::TranslationAgentWithDefaultInstructionsTemplateTest < Active
 
     assert_equal "# Default Instructions\n\nTranslate the given text from one language to another.\n", translate_prompt.instructions
   end
+
+  test "it uses instructions from default instructions template with dynamic param in the template" do
+    translate_prompt = ScopedAgents::TranslationAgentWithDefaultInstructionsTemplate.with(
+      message: "Hi, I'm Justin", locale: "japanese", source_language: "english"
+    ).translate
+
+    assert_equal "# Default Instructions\n\nTranslate the given text from english language to another.\n", translate_prompt.instructions
+  end
 end

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    activeagent (0.4.1)
+    activeagent (0.4.2)
       actionpack (>= 7.2, < 9.0)
       actionview (>= 7.2, < 9.0)
       activejob (>= 7.2, < 9.0)

--- a/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
+++ b/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
@@ -1,7 +1,7 @@
 module ScopedAgents
   class TranslationAgentWithCustomInstructionsTemplate < ApplicationAgent
     generate_with :openai, instructions: {
-      template: :custom_instructions, locals: {from: "English", to: "French"}
+      template: :custom_instructions, locals: { from: "English", to: "French" }
     }
 
     before_action :add_custom_instructions
@@ -11,7 +11,7 @@ module ScopedAgents
     end
 
     def translate_with_overridden_instructions
-      prompt(instructions: {template: :overridden_instructions})
+      prompt(instructions: { template: :overridden_instructions })
     end
 
     private

--- a/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
+++ b/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
@@ -5,6 +5,7 @@ module ScopedAgents
     }
 
     def translate
+      @additional_instruction = "translation additional instruction"
       prompt
     end
 

--- a/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
+++ b/test/dummy/app/agents/scoped_agents/translation_agent_with_custom_instructions_template.rb
@@ -1,16 +1,23 @@
 module ScopedAgents
   class TranslationAgentWithCustomInstructionsTemplate < ApplicationAgent
     generate_with :openai, instructions: {
-      template: :custom_instructions, locals: { from: "English", to: "French" }
+      template: :custom_instructions, locals: {from: "English", to: "French"}
     }
 
+    before_action :add_custom_instructions
+
     def translate
-      @additional_instruction = "translation additional instruction"
       prompt
     end
 
     def translate_with_overridden_instructions
-      prompt(instructions: { template: :overridden_instructions })
+      prompt(instructions: {template: :overridden_instructions})
+    end
+
+    private
+
+    def add_custom_instructions
+      @additional_instruction = "translation additional instruction"
     end
   end
 end

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/custom_instructions.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_custom_instructions_template/custom_instructions.text.erb
@@ -1,3 +1,4 @@
 # Custom Instructions
 
+<%= @additional_instruction %>
 Translate the given text from <%= from %> to <%= to %>.

--- a/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/instructions.text.erb
+++ b/test/dummy/app/views/scoped_agents/translation_agent_with_default_instructions_template/instructions.text.erb
@@ -1,3 +1,3 @@
 # Default Instructions
 
-Translate the given text from one language to another.
+Translate the given text from <%= params[:source_language].presence || "one" %> language to another.


### PR DESCRIPTION
I’m not sure it’s entirely right to wait for personalized parameters from specific actions inside a general template, but I think we still need this kind of flexibility.
One possible option is to use lazy instruction generation — generating instructions only when the necessary context is already available.
Or maybe there’s a better solution we should consider?

Closes https://github.com/activeagents/activeagent/issues/100