### PR TITLE
Move rails gem to development dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       activejob (>= 7.2, < 9.0)
       activemodel (>= 7.2, < 9.0)
       activesupport (>= 7.2, < 9.0)
-      rails (>= 7.2, < 9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -268,7 +267,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
     stringio (3.1.7)
-    thor (1.3.2)
+    thor (1.4.0)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -297,6 +296,7 @@ DEPENDENCIES
   activeagent!
   jbuilder
   puma
+  rails
   rubocop-rails-omakase
   ruby-anthropic (~> 0.4.2)
   ruby-openai (~> 8.1.0)

--- a/activeagent.gemspec
+++ b/activeagent.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel", ">= 7.2", "< 9.0"
   spec.add_dependency "activejob", ">= 7.2", "< 9.0"
 
-  spec.add_dependency "rails", ">= 7.2", "< 9.0"
   spec.add_development_dependency "jbuilder"
+  spec.add_development_dependency "rails"
 end


### PR DESCRIPTION
A runtime dependency on the `rails` meta-gem forces projects to pull in the entire framework instead of just the relevant components.