### PR TITLE
Fix gemspec `files` references

### DIFF
--- a/activeagent.gemspec
+++ b/activeagent.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.description = "The only agent-oriented AI framework designed for Rails, where Agents are Controllers. Build AI features with less complexity using the MVC conventions you love."
   spec.authors = [ "Justin Bowen" ]
   spec.email = "jusbowen@gmail.com"
-  spec.files = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "lib/**/*"]
+  spec.files = Dir["CHANGELOG.md", "README.md", "LICENSE", "lib/**/*"]
   spec.require_paths = "lib"
   spec.homepage = "https://activeagents.ai"
   spec.license = "MIT"


### PR DESCRIPTION
This pull request fixes a "critical bug" (according to AI) by updating the `files` array in the gemspec to the right files that exist in the repo:

- `README.rdoc` → `README.md`
- `MIT-LICENSE` → `LICENSE`