### PR TITLE
Add `rake test` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,8 @@
 require "bundler/setup"
-
 require "bundler/gem_tasks"
+
+desc "Run tests"
+task :test do
+  $: << File.expand_path("test", __dir__)
+  require "rails/plugin/test"
+end


### PR DESCRIPTION
I was trying to run the tests and noticed there is not `test` rake test, so this pull request adds a rake `test` so can run `bundle exec rake test` as it's the convention on most Ruby projects.