### PR TITLE
fix generation callbacks

### DIFF
--- a/lib/active_agent/action_prompt/prompt.rb
+++ b/lib/active_agent/action_prompt/prompt.rb
@@ -4,7 +4,7 @@ module ActiveAgent
   module ActionPrompt
     class Prompt
       attr_reader :messages, :instructions
-      attr_accessor :actions, :body, :content_type, :context_id, :message, :options, :mime_version, :charset, :context, :parts, :params, :action_choice, :agent_class, :output_schema
+      attr_accessor :actions, :body, :content_type, :context_id, :message, :options, :mime_version, :charset, :context, :parts, :params, :action_choice, :agent_class, :output_schema, :action_name
 
       def initialize(attributes = {})
         @options = attributes.fetch(:options, {})
@@ -26,6 +26,7 @@ module ActiveAgent
         @parts = attributes.fetch(:parts, [])
         @output_schema = attributes.fetch(:output_schema, nil)
         @messages = Message.from_messages(@messages)
+        @action_name = attributes.fetch(:action_name, nil)
         set_message if attributes[:message].is_a?(String) || @body.is_a?(String) && @message&.content
         set_messages if @instructions.present?
       end

--- a/lib/active_agent/callbacks.rb
+++ b/lib/active_agent/callbacks.rb
@@ -11,26 +11,21 @@ module ActiveAgent
     end
 
     module ClassMethods
-      # Defines a callback that will get called right before the
-      # prompt is sent to the generation provider method.
-      def before_generation(*filters, &blk)
-        set_callback(:generation, :before, *filters, &blk)
-      end
-
-      # Defines a callback that will get called right after the
-      # prompt's generation method is finished.
-      def after_generation(*filters, &blk)
-        set_callback(:generation, :after, *filters, &blk)
-      end
-
-      # Defines a callback that will get called around the prompt's generation method.
-      def around_generation(*filters, &blk)
-        set_callback(:generation, :around, *filters, &blk)
+      # # Defines a callback that will get called right before/after/around the
+      # # generation provider method.
+      [ :before, :after, :around ].each do |callback|
+        define_method "#{callback}_generation" do |*names, &blk|
+          _insert_callbacks(names, blk) do |name, options|
+            set_callback(:generation, callback, name, options)
+          end
+        end
       end
 
       # Defines a callback for handling streaming responses during generation
-      def on_stream(*filters, &blk)
-        set_callback(:stream, :before, *filters, &blk)
+      def on_stream(*names, &blk)
+        _insert_callbacks(names, blk) do |name, options|
+          set_callback(:stream, :before, name, options)
+        end
       end
     end
 

--- a/lib/active_agent/generation_provider/anthropic_provider.rb
+++ b/lib/active_agent/generation_provider/anthropic_provider.rb
@@ -40,7 +40,7 @@ module ActiveAgent
         proc do |chunk|
           if new_content = chunk.dig(:delta, :text)
             message.content += new_content
-            agent_stream.call(message) if agent_stream.respond_to?(:call)
+            agent_stream.call(message, nil, false, prompt.action_name) if agent_stream.respond_to?(:call)
           end
         end
       end

--- a/lib/active_agent/generation_provider/open_ai_provider.rb
+++ b/lib/active_agent/generation_provider/open_ai_provider.rb
@@ -61,7 +61,7 @@ module ActiveAgent
             message.generation_id = chunk.dig("id")
             message.content += new_content
 
-            agent_stream.call(message, new_content, false) do |message, new_content|
+            agent_stream.call(message, new_content, false, prompt.action_name) do |message, new_content|
               yield message, new_content if block_given?
             end
           elsif chunk.dig("choices", 0, "delta", "tool_calls") && chunk.dig("choices", 0, "delta", "role")
@@ -70,7 +70,7 @@ module ActiveAgent
             @response = ActiveAgent::GenerationProvider::Response.new(prompt:, message:)
           end
 
-          agent_stream.call(message, nil, true) do |message|
+          agent_stream.call(message, nil, true, prompt.action_name) do |message|
             yield message, nil if block_given?
           end
         end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,0 +1,256 @@
+require "test_helper"
+
+class BroadcastSpy
+  attr_reader :calls
+
+  def initialize
+    @calls = []
+  end
+
+  def broadcast(*args)
+    @calls << args
+    true
+  end
+end
+
+class AgentWithCallbacks < ActiveAgent::Base
+  layout "agent"
+
+  generate_with :openai, model: "gpt-4o-mini", instructions: "You are a helpful assistant."
+end
+
+class CallbacksWithConditions < AgentWithCallbacks
+  before_generation :update_context_id, only: :test_action
+  after_generation :filter_response_message, except: :test_action
+  on_stream :broadcast_message, only: :stream_action
+
+  def test_action
+    prompt_context(message: "Show me a cat")
+  end
+
+  def another_test_action
+    prompt_context(message: "Show me a cat")
+  end
+
+  def stream_action
+    prompt_context(message: "Stream this message", stream: true)
+  end
+
+  private
+
+  def update_context_id
+    context.context_id = 2000
+  end
+
+  def filter_response_message
+    generation_provider.response.message.content = "[FILTERED]"
+  end
+
+  def broadcast_message
+    response = generation_provider.response
+
+    ActionCable.server.broadcast("broadcast_message", response)
+  end
+end
+
+class TestCallbacksWithConditions < ActiveSupport::TestCase
+  def setup
+    @agent_class = CallbacksWithConditions
+  end
+
+  test "when :only is specified, a before action is triggered on that action" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.test_action.generate_now
+      assert_equal 2000, generation_result.prompt.context_id
+    end
+
+    VCR.use_cassette("streaming_agent_stream_response") do
+      spy = BroadcastSpy.new
+
+      ActionCable.stub :server, spy do
+        @agent_class.stream_action.generate_now
+      end
+
+      assert_equal spy.calls.size, 30
+    end
+  end
+
+  test "when :only is specified, a before action is not triggered on other actions" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.another_test_action.generate_now
+      assert_nil generation_result.prompt.context_id
+    end
+  end
+
+  test "when :except is specified, an after action is not triggered on that action" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.test_action.generate_now
+      assert_not_equal "[FILTERED]", generation_result.message.content
+    end
+  end
+
+  test "when :except is specified, an after action is triggered on other actions" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.another_test_action.generate_now
+      assert_equal "[FILTERED]", generation_result.message.content
+    end
+  end
+end
+
+class CallbacksWithChangedConditions < CallbacksWithConditions
+  before_generation :update_context_id, only: :another_test_action
+end
+
+class TestCallbacksWithChangedConditions < ActiveSupport::TestCase
+  def setup
+    @agent_class = CallbacksWithChangedConditions
+  end
+
+  test "when a callback is modified in a child with :only, it works for the :only action" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.another_test_action.generate_now
+      assert_equal 2000, generation_result.prompt.context_id
+    end
+  end
+
+  test "when a callback is modified in a child with :only, it does not work for other actions" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.test_action.generate_now
+      assert_nil generation_result.prompt.context_id
+    end
+  end
+end
+
+class CallbacksWithArrayConditions < AgentWithCallbacks
+  before_generation :update_context_id, only: %i[test_action another_test_action]
+
+  def test_action
+    prompt_context(message: "Show me a cat")
+  end
+
+  def another_test_action
+    prompt_context(message: "Show me a cat")
+  end
+
+  def yet_another_test_action
+    prompt_context(message: "Show me a cat")
+  end
+
+  private
+
+  def update_context_id
+    context.context_id = 2000
+  end
+end
+
+class TestCallbacksWithArrayConditions < ActiveSupport::TestCase
+  def setup
+    @agent_class = CallbacksWithArrayConditions
+  end
+
+  test "when :only is specified with an array, a before action is triggered on that action" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.test_action.generate_now
+      assert_equal 2000, generation_result.prompt.context_id
+    end
+
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.another_test_action.generate_now
+      assert_equal 2000, generation_result.prompt.context_id
+    end
+  end
+
+  test "when :only is specified with an array, a before action is not triggered on other actions" do
+    VCR.use_cassette("openai_prompt_context_response") do
+      generation_result = @agent_class.yet_another_test_action.generate_now
+      assert_nil generation_result.prompt.context_id
+    end
+  end
+end
+
+class AgentWithDefaultStreamOptionCallbacks < ApplicationAgent
+  generate_with :openai,
+                model: "gpt-4.1-nano",
+                instructions: "You're a chat agent. Your job is to help users with their questions.",
+                stream: true
+
+  on_stream :broadcast_message
+
+  def stream_action
+    prompt_context(message: "Stream this message")
+  end
+
+  def another_stream_action
+    prompt_context(message: "Stream this message")
+  end
+
+  private
+
+  def broadcast_message
+    response = generation_provider.response
+
+    ActionCable.server.broadcast("broadcast_message", response)
+  end
+end
+
+class TestAgentWithDefaultStreamOptionCallbacks < ActiveSupport::TestCase
+  def setup
+    @agent_class = AgentWithDefaultStreamOptionCallbacks
+  end
+
+  test "when :filter option is not specified, an on_stream action is triggered on any action" do
+    VCR.use_cassette("streaming_agent_stream_response") do
+      spy = BroadcastSpy.new
+
+      ActionCable.stub :server, spy do
+        @agent_class.stream_action.generate_now
+      end
+
+      assert_equal spy.calls.size, 30
+    end
+
+    VCR.use_cassette("streaming_agent_stream_response") do
+      spy = BroadcastSpy.new
+
+      ActionCable.stub :server, spy do
+        @agent_class.another_stream_action.generate_now
+      end
+
+      assert_equal spy.calls.size, 30
+    end
+  end
+end
+
+class AgentWithDefaultStreamOptionWithChangedConditionCallbacks < AgentWithDefaultStreamOptionCallbacks
+  on_stream :broadcast_message, only: :stream_action
+end
+
+class TestAgentWithDefaultStreamOptionWithChangedConditionCallbacks < ActiveSupport::TestCase
+  def setup
+    @agent_class = AgentWithDefaultStreamOptionWithChangedConditionCallbacks
+  end
+
+  test "when a callback is modified in a child with :only, it works for the :only action" do
+    VCR.use_cassette("streaming_agent_stream_response") do
+      spy = BroadcastSpy.new
+
+      ActionCable.stub :server, spy do
+        @agent_class.stream_action.generate_now
+      end
+
+      assert_equal spy.calls.size, 30
+    end
+  end
+
+  test "when a callback is modified in a child with :only, it does not work for other actions" do
+    VCR.use_cassette("streaming_agent_stream_response") do
+      spy = BroadcastSpy.new
+
+      ActionCable.stub :server, spy do
+        @agent_class.another_stream_action.generate_now
+      end
+
+      assert_empty spy.calls, "Expected no broadcast calls"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/migrate", __dir__) ]
 require "rails/test_help"
 require "vcr"
+require "minitest/mock"
 
 VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"


### PR DESCRIPTION
I decided to use the method [_insert_callbacks](https://edgeapi.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-_insert_callbacks), which is internally used by Rails, in order to normalize options such as `only` and `except`.

I also had to pass the current `action_name` into the prompt so that when `on_stream` callbacks are triggered, we have the context needed for filtering. It might be possible to reuse the existing action_choice attribute instead — I’d appreciate some help here, as I’m not entirely sure what the original intention behind that attribute was.

It might also make sense to introduce a separate `stream_handler` attribute in the prompt, which would hold the actual Proc. We could then assign `agent_stream` to it if `options[:stream]` is true. Alternatively, do we want to allow the user to pass in their own custom Proc? If so, the callback logic might become inconsistent — this probably needs some more thought.

For now, I’ve moved the stream Proc assignment out of `generate_with`, since it started behaving incorrectly in inherited classes.

Closes https://github.com/activeagents/activeagent/issues/92