### PR TITLE
Add an agent_views_directory configuration to active_agent.yml

### DIFF
--- a/lib/active_agent/railtie.rb
+++ b/lib/active_agent/railtie.rb
@@ -45,7 +45,8 @@ module ActiveAgent
         register_interceptors(options.delete(:interceptors))
         register_preview_interceptors(options.delete(:preview_interceptors))
         register_observers(options.delete(:observers))
-        self.view_paths = [ "#{Rails.root}/app/views" ]
+        views_dir = ActiveAgent.config["agent_views_directory"] || "app/views"
+        self.view_paths = [ "#{Rails.root}/#{views_dir}" ]
         self.preview_paths |= options[:preview_paths]
 
         if (generation_job = options.delete(:generation_job))

--- a/lib/generators/active_agent/templates/active_agent.yml
+++ b/lib/generators/active_agent/templates/active_agent.yml
@@ -1,4 +1,5 @@
 development:
+  agent_views_directory: "app/views/agents"
   openai:
     service: "OpenAI"
     api_key: <%%= Rails.application.credentials.dig(:openai, :api_key) %>

--- a/lib/generators/erb/agent_generator.rb
+++ b/lib/generators/erb/agent_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators/erb"
+require "active_agent"
 
 module Erb # :nodoc:
   module Generators # :nodoc:
@@ -10,7 +11,8 @@ module Erb # :nodoc:
       class_option :formats, type: :array, default: [ "text" ], desc: "Specify formats to generate (text, html, json)"
 
       def copy_view_files
-        view_base_path = File.join("app/views", class_path, file_name + "_agent")
+        agent_views_dir = agent_views_directory
+        view_base_path = File.join(agent_views_dir, class_path, file_name + "_agent")
         empty_directory view_base_path
 
         if behavior == :invoke
@@ -37,6 +39,13 @@ module Erb # :nodoc:
 
       def file_name
         @_file_name ||= super.sub(/_agent\z/i, "")
+      end
+
+      def agent_views_directory
+        # Ensure config is loaded
+        ActiveAgent.load_configuration(Rails.root.join("config", "active_agent.yml")) unless ActiveAgent.config
+
+        ActiveAgent.config["agent_views_directory"]
       end
     end
   end

--- a/lib/generators/erb/agent_generator.rb
+++ b/lib/generators/erb/agent_generator.rb
@@ -45,7 +45,7 @@ module Erb # :nodoc:
         # Ensure config is loaded
         ActiveAgent.load_configuration(Rails.root.join("config", "active_agent.yml")) unless ActiveAgent.config
 
-        ActiveAgent.config["agent_views_directory"]
+        ActiveAgent.config["agent_views_directory"] || "app/views"
       end
     end
   end


### PR DESCRIPTION
This will allow putting agent views into `/app/views/agents/`, for example, instead of `/app/views/`. 

This follows the `/app/views/mailers/` convention, but also allows putting views into a completely different location like `/app/agents/views`, for example. 

Layouts currently stay in `/app/views/layouts`, though. 

Note, this keeps the default view path as `/app/views/`, but the generator will create a template with a setting of `/app/views/agents/` which may not be what you want. 

This will keep the views directory slightly cleaner, e.g.:
<img width="213" height="90" alt="Screenshot 2025-08-03 at 2 04 20 PM" src="https://github.com/user-attachments/assets/596b66e8-e3bd-4c93-82af-ba248ea3b7c3" />

Oh also this doesn't change anything in the `USAGE` files that mention this path. 
