### PR TITLE
Fix Secrets Sanitizing 

### DIFF
--- a/lib/active_agent.rb
+++ b/lib/active_agent.rb
@@ -14,6 +14,8 @@ require "active_support/lazy_load_hooks"
 module ActiveAgent
   extend ActiveSupport::Autoload
 
+  SECRETS_KEYS = %w[access_token api_key]
+
   eager_autoload do
     autoload :Collector
   end
@@ -34,11 +36,6 @@ module ActiveAgent
   class << self
     attr_accessor :config
 
-    def filter_credential_keys(example)
-      example.gsub(Rails.application.credentials.dig(:openai, :api_key), "<OPENAI_API_KEY>")
-        .gsub(Rails.application.credentials.dig(:open_router, :api_key), "<OPEN_ROUTER_API_KEY>")
-    end
-
     def eager_load!
       super
 
@@ -47,10 +44,14 @@ module ActiveAgent
       end
     end
 
+    # @return [void]
     def configure
       yield self
+
+      sanitizers_reset!
     end
 
+    # @return [void]
     def load_configuration(file)
       if File.exist?(file)
         config_file = YAML.load(ERB.new(File.read(file)).result, aliases: true)
@@ -59,6 +60,39 @@ module ActiveAgent
       else
         @config = {}
       end
+
+      sanitizers_reset!
+    end
+
+    # @return [Hash] The current sanitizers.
+    def sanitizers
+      @sanitizers ||= begin
+        sanitizers = {}
+
+        config.each do |provider, credentials|
+          credentials.slice(*SECRETS_KEYS).compact.each do |name, secret|
+            next if secret.blank?
+
+            sanitizers[secret] = "<#{provider.upcase}_#{name.upcase}>"
+          end
+        end
+
+        sanitizers
+      end
+    end
+
+    # return [void]
+    def sanitizers_reset!
+      @sanitizers = nil
+    end
+
+    # @return [String] The sanitized string with sensitive data replaced by placeholders.
+    def sanitize_credentials(string)
+      sanitizers.each do |secret, placeholder|
+        string = string.gsub(secret, placeholder)
+      end
+
+      string
     end
   end
 end

--- a/lib/active_agent/action_prompt/prompt.rb
+++ b/lib/active_agent/action_prompt/prompt.rb
@@ -81,7 +81,7 @@ module ActiveAgent
 
       def inspect
         "#<#{self.class}:0x#{object_id.to_s(16)}\n" +
-          "  @options=#{@options.inspect.gsub(Rails.application.credentials.dig(:openai, :api_key), '<OPENAI_API_KEY>')}\n" +
+          "  @options=#{ActiveAgent.sanitize_credentials(@options.inspect)}\n" +
           "  @actions=#{@actions.inspect}\n" +
           "  @action_choice=#{@action_choice.inspect}\n" +
           "  @instructions=#{@instructions.inspect}\n" +

--- a/lib/active_agent/sanitizers.rb
+++ b/lib/active_agent/sanitizers.rb
@@ -1,0 +1,40 @@
+module ActiveAgent
+  module Sanitizers
+    extend ActiveSupport::Concern
+
+    SECRETS_KEYS = %w[access_token api_key]
+
+    class_methods do
+      # @return [Hash] The current sanitizers.
+      def sanitizers
+        @sanitizers ||= begin
+          sanitizers = {}
+
+          config.each do |provider, credentials|
+            credentials.slice(*SECRETS_KEYS).compact.each do |name, secret|
+              next if secret.blank?
+
+              sanitizers[secret] = "<#{provider.upcase}_#{name.upcase}>"
+            end
+          end
+
+          sanitizers
+        end
+      end
+
+      # return [void]
+      def sanitizers_reset!
+        @sanitizers = nil
+      end
+
+      # @return [String] The sanitized string with sensitive data replaced by placeholders.
+      def sanitize_credentials(string)
+        sanitizers.each do |secret, placeholder|
+          string = string.gsub(secret, placeholder)
+        end
+
+        string
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,7 +81,7 @@ def doc_example_output(example = nil, test_name = nil)
     content << "```"
   else
     content << "```ruby"
-    content << ActiveAgent.filter_credential_keys(example.to_s)
+    content << ActiveAgent.sanitize_credentials(example.to_s)
     content << "```"
   end
 
@@ -91,8 +91,10 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into :webmock
-  config.filter_sensitive_data("<OPENAI_API_KEY>") { Rails.application.credentials.dig(:openai, :api_key) }
-  config.filter_sensitive_data("<OPEN_ROUTER_API_KEY>") { Rails.application.credentials.dig(:open_router, :api_key) }
+
+  ActiveAgent.sanitizers.each do |secret, placeholder|
+    config.filter_sensitive_data(placeholder) { secret }
+  end
 end
 
 # Load fixtures from the engine


### PR DESCRIPTION
While attempting to get this gem working locally in my project I ran into an issue where `prompt#inspect` would error because I am not setting `Rails.application.credentials.dig(:openai, :api_key)` because I am not using OpenAI and that path within the credentials store.

This patch fixes that issue, while also ensuring that any credentials loaded via the config, not just ones that happen to also be loaded via the same path in `Rails.credentials` are correctly sanitized from logs and VCR.