### PR TITLE
Update message_json extraction logic in OpenAI provider

### DIFF
--- a/lib/active_agent/generation_provider/open_ai_provider.rb
+++ b/lib/active_agent/generation_provider/open_ai_provider.rb
@@ -161,7 +161,7 @@ module ActiveAgent
       end
 
       def responses_response(response)
-        message_json = response.dig("output", 0)
+        message_json = response["output"].find { |output_item| output_item["type"] == "message" }
         message_json["id"] = response.dig("id") if message_json["id"].blank?
 
         message = ActiveAgent::ActionPrompt::Message.new(


### PR DESCRIPTION
When using responses api and reasoning models like o3, the model returns in the first message "type"=>"reasoning" which does not contain a response from the model