### PR TITLE
Allow accessing stream deltas

### DIFF
--- a/lib/active_agent.rb
+++ b/lib/active_agent.rb
@@ -23,6 +23,7 @@ module ActiveAgent
 
   autoload :Base
   autoload :Callbacks
+  autoload :Streaming
   autoload :InlinePreviewInterceptor
   autoload :PromptHelper
   autoload :Generation

--- a/lib/active_agent/action_prompt/base.rb
+++ b/lib/active_agent/action_prompt/base.rb
@@ -10,6 +10,7 @@ module ActiveAgent
     class Base < AbstractController::Base
       include Callbacks
       include GenerationProvider
+      include Streaming
       include QueuedGeneration
       include Rescuable
       include Parameterized

--- a/lib/active_agent/callbacks.rb
+++ b/lib/active_agent/callbacks.rb
@@ -7,7 +7,6 @@ module ActiveAgent
     included do
       include ActiveSupport::Callbacks
       define_callbacks :generation, skip_after_callbacks_if_terminated: true
-      define_callbacks :stream, skip_after_callbacks_if_terminated: true
     end
 
     module ClassMethods
@@ -19,20 +18,6 @@ module ActiveAgent
             set_callback(:generation, callback, name, options)
           end
         end
-      end
-
-      # Defines a callback for handling streaming responses during generation
-      def on_stream(*names, &blk)
-        _insert_callbacks(names, blk) do |name, options|
-          set_callback(:stream, :before, name, options)
-        end
-      end
-    end
-
-    # Helper method to run stream callbacks
-    def run_stream_callbacks(message, delta = nil, stop = false)
-      run_callbacks(:stream) do
-        yield(message, delta, stop) if block_given?
       end
     end
   end

--- a/lib/active_agent/streaming.rb
+++ b/lib/active_agent/streaming.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Streaming
+    extend ActiveSupport::Concern
+
+    class StreamChunk < Data.define(:delta, :stop)
+    end
+
+    attr_accessor :stream_chunk
+
+    included do
+      include ActiveSupport::Callbacks
+      define_callbacks :stream, skip_after_callbacks_if_terminated: true
+    end
+
+    module ClassMethods
+      # Defines a callback for handling streaming responses during generation
+      def on_stream(*names, &blk)
+        _insert_callbacks(names, blk) do |name, options|
+          set_callback(:stream, :before, name, options)
+        end
+      end
+    end
+
+    # Helper method to run stream callbacks
+    def run_stream_callbacks(message, delta = nil, stop = false)
+      @stream_chunk = StreamChunk.new(delta, stop)
+      run_callbacks(:stream) do
+        yield(message, delta, stop) if block_given?
+      end
+    end
+  end
+end

--- a/test/dummy/app/agents/streaming_agent.rb
+++ b/test/dummy/app/agents/streaming_agent.rb
@@ -12,11 +12,12 @@ class StreamingAgent < ApplicationAgent
   def broadcast_message
     response = generation_provider.response
 
+    message = params[:delta] ? stream_chunk.delta : response.message.content
     # Broadcast the message to the specified channel
     ActionCable.server.broadcast(
       "#{response.message.generation_id}_messages",
       partial: "streaming_agent/message",
-      locals: { message: response.message.content, scroll_to: true }
+      locals: { message:, scroll_to: true }
     )
   end
 end


### PR DESCRIPTION
Allow accessing stream delta messages, not only the accumulated message.

Also, moved streaming agent configuration to its own module (from Callbacks).

We have to use an intermediate variable to store the chunk info, because Rails callbacks do not allow passing arguments 🤷‍♂️ Ideally, I would love to have smth like:

```ruby
on_stream :handle_chunk

def handle_chunk(chunk)
  # ...
end
```

