### PR TITLE
Fix ruby-openai gem constraint

### DIFF
--- a/activeagent.gemspec
+++ b/activeagent.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "jbuilder", "~> 2.14"
   spec.add_development_dependency "rails"
 
-  spec.add_development_dependency "ruby-openai", "~> 8.2.0"
+  spec.add_development_dependency "ruby-openai", ">= 8.1.0"
   spec.add_development_dependency "ruby-anthropic", "~> 0.4.2"
 
   spec.add_development_dependency "standard"

--- a/lib/active_agent/generation_provider/open_ai_provider.rb
+++ b/lib/active_agent/generation_provider/open_ai_provider.rb
@@ -1,5 +1,5 @@
 begin
-  gem "ruby-openai", "~> 8.2.0"
+  gem "ruby-openai", ">= 8.1.0"
   require "openai"
 rescue LoadError
   raise LoadError, "The 'ruby-openai' gem is required for OpenAIProvider. Please add it to your Gemfile and run `bundle install`."


### PR DESCRIPTION
After updating ruby-openai to 8.2.0 I was getting an error saying the gem wasn't present. This should fix that.