### PR TITLE
Prevent agent class options mutation

### DIFF
--- a/lib/active_agent/action_prompt/base.rb
+++ b/lib/active_agent/action_prompt/base.rb
@@ -280,7 +280,7 @@ module ActiveAgent
       def initialize # :nodoc:
         super
         @_prompt_was_called = false
-        @_context = ActiveAgent::ActionPrompt::Prompt.new(options: self.class.options || {}, agent_instance: self)
+        @_context = ActiveAgent::ActionPrompt::Prompt.new(options: self.class.options&.deep_dup || {}, agent_instance: self)
       end
 
       def process(method_name, *args) # :nodoc:


### PR DESCRIPTION
We modify options in-place here: https://github.com/activeagents/activeagent/blob/7e0db7a45073fd2baee68ed70e478c5df58ace8f/lib/active_agent/action_prompt/base.rb#L344-L345

Extensions may modify options (e.g., temporary enable streaming), too. 

Both scenarios can lead to unexpected results.