### PR TITLE
chore: remove `standard` from dev dependencies

### DIFF
--- a/activeagent.gemspec
+++ b/activeagent.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "anthropic", "~> 1.12"
   spec.add_development_dependency "openai", "~> 0.34"
 
-  spec.add_development_dependency "standard"
   spec.add_development_dependency "rubocop-rails-omakase"
 
   spec.add_development_dependency "capybara", "~> 3.40"


### PR DESCRIPTION
`.standard.yml` doesn't exist, and `.rubocop.yml` shows we use `rubocop-rails-omakase`. It should be enough to use `rubocop-rails-omakase` only.