### PR TITLE
Update OpenAI gem name and prompt method in Getting Started Docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,7 +25,7 @@ Add your provider gem:
 ::: code-group
 
 ```bash [OpenAI]
-bundle add openai
+bundle add ruby-openai
 ```
 
 ```bash [Anthropic]
@@ -70,7 +70,7 @@ See **[Configuration](/framework/configuration)** for environment-specific setti
 Test your setup with direct generation:
 
 ```ruby
-response = ApplicationAgent.prompt(message: "Hello, world!").generate_now
+response = ApplicationAgent.prompt_with(message: "Hello, world!").generate_now
 puts response.message
 # => "Hello! How can I help you today?"
 ```


### PR DESCRIPTION
As I was setting this up, I noticed some differences between the docs and what worked. I'm not sure if this is the right place to propose these changes. Let me know.

<img width="1472" height="190" alt="CleanShot 2025-11-19 at 11 01 38@2x" src="https://github.com/user-attachments/assets/156b69d7-a785-4cb9-93b4-c37a3bad42c1" />

<img width="1462" height="208" alt="CleanShot 2025-11-19 at 11 04 12@2x" src="https://github.com/user-attachments/assets/52148323-cda7-4afd-9844-90027ca752a5" />
