### PR TITLE
Handle message when the role is developer when using OpenAI provider with instructions

### DIFF
--- a/lib/active_agent/providers/common/messages/_types.rb
+++ b/lib/active_agent/providers/common/messages/_types.rb
@@ -37,7 +37,7 @@ module ActiveAgent
                 role = hash[:role]&.to_s
 
                 case role
-                when "system"
+                when "system", "developer"
                   nil # System messages are dropped in common format, replaced by Instructions
                 when "user", nil
                   # Handle both standard format and format with `text` key

--- a/test/providers/common/messages/types_test.rb
+++ b/test/providers/common/messages/types_test.rb
@@ -31,6 +31,12 @@ module ActiveAgent
             assert_nil result
           end
 
+          test "MessageType drops developer messages" do
+            message_type = create_message_type
+            result = message_type.cast({ role: "developer", content: "Developer prompt" })
+            assert_nil result
+          end
+
           test "MessagesType casts array of Hash messages to Message objects" do
             messages_type = create_messages_type
             messages = [


### PR DESCRIPTION
## Summary

Extends `MessageType` to drop messages with `"developer"` role, consistent with how `"system"` messages are handled. Developer messages are filtered out during message casting, as they are replaced by Instructions in the common format.

## Changes

- **Modified `lib/active_agent/providers/common/messages/_types.rb`**:
  - Updated the case statement to include `"developer"` alongside `"system"` when dropping messages
  - Both roles now return `nil` during casting

- **Added test in `test/providers/common/messages/types_test.rb`**:
  - New test case: `"MessageType drops developer messages"`
  - Verifies that developer role messages are properly dropped (return `nil`)

## Behavior

When `MessageType#cast` receives a hash with `role: "developer"`, it now returns `nil`, matching the behavior for `role: "system"`. This ensures developer messages are filtered out and replaced by Instructions, maintaining consistency with the common message format.

Closes #285 
