### PR TITLE
Fix CI failing due to relative BUNDLE_GEMFILE path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
       CI: true
       ANTHROPIC_API_KEY: ANTHROPIC_API_KEY
       OPEN_AI_API_KEY: OPEN_AI_API_KEY
@@ -59,12 +59,10 @@ jobs:
       env:
         RAILS_ENV: test
         RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
+      working-directory: test/dummy
       run: |
-        cd test/dummy
         bundle exec rails db:create
         bundle exec rails db:migrate
-        cd ../..
     - name: Run tests
       env:
         RAILS_ENV: test
@@ -77,7 +75,7 @@ jobs:
     env:
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
       CI: true
       ANTHROPIC_API_KEY: ANTHROPIC_API_KEY
       OPEN_AI_API_KEY: OPEN_AI_API_KEY
@@ -105,12 +103,10 @@ jobs:
       env:
         RAILS_ENV: test
         RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
+      working-directory: test/dummy
       run: |
-        cd test/dummy
         bundle exec rails db:create
         bundle exec rails db:migrate
-        cd ../..
     - name: Run tests
       env:
         RAILS_ENV: test

--- a/activeagent.gemspec
+++ b/activeagent.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", ">= 7.2", "<= 9.0"
 
   spec.add_development_dependency "jbuilder", "~> 2.14"
-  spec.add_development_dependency "rails", "~> 8.1.1"
 
   spec.add_development_dependency "anthropic", "~> 1.12"
   spec.add_development_dependency "openai", "~> 0.34"
@@ -38,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ostruct"
   spec.add_development_dependency "puma"
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
 

--- a/gemfiles/anthropic_1.12.gemfile
+++ b/gemfiles/anthropic_1.12.gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
 gem "anthropic", "~> 1.12.0"
+gem "minitest", "~> 5.0"
+gem "rails", "~> 8.0.0"
+gem "sqlite3", "~> 2.0"
 
 gemspec path: ".."

--- a/gemfiles/anthropic_1.14.gemfile
+++ b/gemfiles/anthropic_1.14.gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
 gem "anthropic", "~> 1.14.0"
+gem "minitest", "~> 5.0"
+gem "rails", "~> 8.0.0"
+gem "sqlite3", "~> 2.0"
 
 gemspec path: ".."

--- a/gemfiles/openai_0.34.gemfile
+++ b/gemfiles/openai_0.34.gemfile
@@ -2,6 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "minitest", "~> 5.0"
 gem "openai", "~> 0.34.0"
+gem "rails", "~> 8.0.0"
+gem "sqlite3", "~> 2.0"
 
 gemspec path: ".."

--- a/gemfiles/openai_0.35.gemfile
+++ b/gemfiles/openai_0.35.gemfile
@@ -2,6 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "minitest", "~> 5.0"
 gem "openai", "~> 0.35.0"
+gem "rails", "~> 8.0.0"
+gem "sqlite3", "~> 2.0"
 
 gemspec path: ".."

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "minitest", "~> 5.0"
 gem "sqlite3", "~> 1.4"
 gem "rails", "~> 7.0"
 

--- a/gemfiles/rails8.gemfile
+++ b/gemfiles/rails8.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "minitest", "~> 5.0"
 gem "sqlite3", "~> 2.0"
 gem "rails", "~> 8.0.0"
 

--- a/gemfiles/railsmain.gemfile
+++ b/gemfiles/railsmain.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "minitest", "~> 5.0"
 gem "sqlite3", "~> 2.0"
 gem "rails", github: "rails/rails"
 


### PR DESCRIPTION
## Summary
- Fix BUNDLE_GEMFILE using relative path which fails when working directory changes to `test/dummy`
- Use absolute path via `${{ github.workspace }}/${{ matrix.gemfile }}` at job level
- Replace `cd test/dummy` with `working-directory` directive for cleaner execution
- Locked minitest to ~> 5.x

## Problem
The CI was failing with:
```
test/dummy/gemfiles/rails8.gemfile not found (Bundler::GemfileNotFound)
```

This happened because BUNDLE_GEMFILE was set to a relative path (`gemfiles/rails8.gemfile`), and when the database setup step changed to `test/dummy`, bundler resolved the path from that directory.

Additionally minitest 6 release broke the test setup, pinning version to 5 fixes the issue for now.

## Test plan
- [x] CI passes on this PR