### PR TITLE
Document Tuning Engines OpenAI-compatible provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,17 @@ development:
     service: "Ollama"
     model: "llama3.2"
 
+  tuning_engines:
+    service: "OpenAI"
+    access_token: <%= Rails.application.credentials.dig(:tuning_engines, :api_key) %>
+    base_url: "https://api.tuningengines.com/v1"
+    model: "gpt-4o-mini"
+
   ruby_llm:
     service: "RubyLLM"
 ```
+
+`tuning_engines` is an OpenAI-compatible gateway configuration for Rails teams that want centralized model routing, policy controls, audit logs, traces, approvals, and cost visibility without changing ActiveAgent code.
 
 ## Features
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -54,6 +54,27 @@ GPT-4o, GPT-4.1, GPT-5, and o3 models. Two APIs available: Responses API (defaul
 
 **Choose when:** You need reliable, high-quality responses with strong reasoning. Vision support and structured output work well. Azure OpenAI compatible.
 
+#### OpenAI-compatible gateways
+
+The OpenAI provider also accepts a custom `base_url`, so Rails apps can route ActiveAgent generations through a governed OpenAI-compatible endpoint. For example, [Tuning Engines](https://www.tuningengines.com/) can sit underneath ActiveAgent to centralize model routing, policy controls, audit logs, traces, approvals, and cost visibility:
+
+```yaml
+production:
+  tuning_engines:
+    service: "OpenAI"
+    access_token: <%= Rails.application.credentials.dig(:tuning_engines, :api_key) %>
+    base_url: "https://api.tuningengines.com/v1"
+    model: "gpt-4o-mini"
+```
+
+Then use it like any other generation provider:
+
+```ruby
+class SupportAgent < ApplicationAgent
+  generate_with :tuning_engines, model: "gpt-4o-mini"
+end
+```
+
 ### [OpenRouter](/providers/open_router)
 **Best for:** Multi-model flexibility, cost optimization, experimentation
 


### PR DESCRIPTION
## Summary

- Adds a small documentation example for using Tuning Engines through the existing OpenAI-compatible configuration surface.
- Keeps the project API unchanged: no dependencies, no adapter changes, and no runtime behavior changes.
- Shows how Ruby/Rails teams can keep this project in charge of application, agent, tool, or workflow logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI application code.

This project already supports OpenAI-compatible configuration. The docs change makes that existing capability discoverable for Ruby/Rails teams without asking the project to add a new provider, dependency, SDK, or runtime integration.

## Testing

- `git diff --check`
