### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/lib/active_agent/dashboard/app/models/active_agent/dashboard/agent.rb
+++ b/lib/active_agent/dashboard/app/models/active_agent/dashboard/agent.rb
@@ -71,7 +71,7 @@ module ActiveAgent
       ].freeze
 
       # Available providers
-      PROVIDERS = %w[openai anthropic ollama openrouter].freeze
+      PROVIDERS = %w[openai anthropic ollama openrouter requesty].freeze
 
       # Returns the configuration as a hash for versioning
       def configuration_snapshot

--- a/lib/active_agent/providers/requesty/_types.rb
+++ b/lib/active_agent/providers/requesty/_types.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../open_ai/chat/_types"
+require_relative "options"
+
+module ActiveAgent
+  module Providers
+    module Requesty
+      # ActiveModel type for casting and serializing Requesty requests.
+      #
+      # Requesty is OpenAI-compatible, so requests use the same shape as the
+      # OpenAI Chat API. This delegates entirely to OpenAI::Chat::RequestType.
+      RequestType = ActiveAgent::Providers::OpenAI::Chat::RequestType
+    end
+  end
+end

--- a/lib/active_agent/providers/requesty/options.rb
+++ b/lib/active_agent/providers/requesty/options.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../open_ai/options"
+
+module ActiveAgent
+  module Providers
+    module Requesty
+      # Configuration options for the Requesty provider.
+      #
+      # Extends OpenAI::Options, overriding the base URL to point at Requesty's
+      # OpenAI-compatible gateway and resolving the API key from REQUESTY_API_KEY.
+      # Requesty does not use organization or project identifiers.
+      #
+      # @example Basic configuration
+      #   options = Options.new(api_key: ENV["REQUESTY_API_KEY"])
+      #
+      # @see https://docs.requesty.ai
+      # @see https://app.requesty.ai/api-keys Requesty API Keys
+      class Options < ActiveAgent::Providers::OpenAI::Options
+        # @!attribute base_url
+        #   @return [String] API endpoint (default: "https://router.requesty.ai/v1")
+        attribute :base_url, :string, as: "https://router.requesty.ai/v1"
+
+        private
+
+        def resolve_api_key(kwargs)
+          kwargs[:api_key] ||
+            kwargs[:access_token] ||
+            ENV["REQUESTY_API_KEY"] ||
+            ENV["REQUESTY_ACCESS_TOKEN"]
+        end
+
+        # Not used as part of Requesty
+        def resolve_organization_id(kwargs) = nil
+        def resolve_project_id(kwargs)      = nil
+      end
+    end
+  end
+end

--- a/lib/active_agent/providers/requesty_provider.rb
+++ b/lib/active_agent/providers/requesty_provider.rb
@@ -1,0 +1,63 @@
+require_relative "_base_provider"
+
+require_gem!(:openai, __FILE__)
+
+require_relative "open_ai_provider"
+require_relative "requesty/_types"
+
+module ActiveAgent
+  module Providers
+    # Provides access to Requesty's OpenAI-compatible LLM gateway.
+    #
+    # Extends the OpenAI provider to work with Requesty's OpenAI-compatible API,
+    # enabling access to multiple AI models through a single interface using the
+    # +provider/model+ naming convention (e.g. +openai/gpt-4o-mini+).
+    #
+    # Requesty is a plain OpenAI-compatible gateway: requests, responses and
+    # transforms are identical to the OpenAI Chat API, so this provider reuses
+    # OpenAI::Chat::RequestType and OpenAI::Chat::Transforms directly. The only
+    # Requesty-specific configuration is the base URL and API key, which live in
+    # Requesty::Options.
+    #
+    # @example Configuration in active_agent.yml
+    #   requesty:
+    #     service: "Requesty"
+    #     api_key: <%= ENV["REQUESTY_API_KEY"] %>
+    #     model: "openai/gpt-4o-mini"
+    #
+    # @see OpenAI::ChatProvider
+    # @see https://docs.requesty.ai
+    class RequestyProvider < OpenAI::ChatProvider
+      # @return [String]
+      def self.service_name
+        "Requesty"
+      end
+
+      # @return [Class]
+      def self.options_klass
+        Requesty::Options
+      end
+
+      # @return [ActiveModel::Type::Value]
+      def self.prompt_request_type
+        OpenAI::Chat::RequestType.new
+      end
+
+      # @return [ActiveModel::Type::Value]
+      def self.embed_request_type
+        OpenAI::Embedding::RequestType.new
+      end
+
+      protected
+
+      # @see BaseProvider#api_response_normalize
+      # @param api_response [OpenAI::Models::ChatCompletion]
+      # @return [Hash] normalized response hash
+      def api_response_normalize(api_response)
+        return api_response unless api_response
+
+        OpenAI::Chat::Transforms.gem_to_hash(api_response)
+      end
+    end
+  end
+end

--- a/test/providers/requesty/provider_loading_test.rb
+++ b/test/providers/requesty/provider_loading_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestyProviderLoadingTest < ActiveSupport::TestCase
+  test "loads RequestyProvider via requesty_provider path" do
+    require "active_agent/providers/requesty_provider"
+
+    assert defined?(ActiveAgent::Providers::RequestyProvider)
+    assert defined?(ActiveAgent::Providers::Requesty::Options)
+  end
+
+  test "provider concern loads Requesty service correctly" do
+    # Simulate how the provider concern loads providers
+    service_name = "Requesty"
+    require "active_agent/providers/#{service_name.underscore}_provider"
+
+    remaps = ActiveAgent::Provider::PROVIDER_SERVICE_NAMES_REMAPS
+    remapped = Hash.new(service_name).merge!(remaps)[service_name]
+
+    assert_equal "Requesty", remapped
+
+    provider_class = ActiveAgent::Providers.const_get("#{remapped.camelize}Provider")
+    assert_equal ActiveAgent::Providers::RequestyProvider, provider_class
+  end
+
+  test "Requesty options default to the Requesty gateway and REQUESTY_API_KEY" do
+    require "active_agent/providers/requesty_provider"
+
+    options = ActiveAgent::Providers::Requesty::Options.new(api_key: "rqsty-test")
+
+    assert_equal "https://router.requesty.ai/v1", options.base_url
+    assert_equal "rqsty-test", options.api_key
+  end
+end


### PR DESCRIPTION
## Summary

Adds a **Requesty** provider, mirroring the existing OpenRouter provider. Requesty (https://requesty.ai) is an OpenAI-compatible LLM gateway, so this provider extends `OpenAI::ChatProvider` and reuses the OpenAI Chat request/response/transform pipeline unchanged.

- Base URL: `https://router.requesty.ai/v1`
- API key: `REQUESTY_API_KEY`
- Model naming: `provider/model` (e.g. `openai/gpt-4o-mini`)
- Requests, responses and transforms are identical to the OpenAI Chat API.

Like the OpenRouter provider, it loads via the existing dynamic provider resolution (`service: "Requesty"` -> `requesty_provider` -> `RequestyProvider`), so no central registry change is required for lookup.

### Design note

The OpenRouter provider also ships routing-specific request machinery under `open_router/` (plugins, provider preferences / `ProviderPreferences`, fallback `models` + `route`, `prediction`, and the `"any"` tool_choice / extended sampling params like `top_k`/`min_p`). Requesty does **not** expose those OpenRouter-routing-specific features, so they are intentionally omitted. The Requesty provider instead reuses the generic OpenAI Chat request type and transforms directly — the same approach the repo already uses for the Azure provider, which is likewise OpenAI-compatible.

## New files

- `lib/active_agent/providers/requesty_provider.rb` — `RequestyProvider < OpenAI::ChatProvider` (service name, options class, OpenAI Chat request/embedding request types, response normalization).
- `lib/active_agent/providers/requesty/options.rb` — `Requesty::Options < OpenAI::Options` (base_url default `https://router.requesty.ai/v1`, resolves `REQUESTY_API_KEY`, no org/project).
- `lib/active_agent/providers/requesty/_types.rb` — `Requesty::RequestType` aliased to `OpenAI::Chat::RequestType`.
- `test/providers/requesty/provider_loading_test.rb` — loading/registration + options defaults.

## Registration / list site

- `lib/active_agent/dashboard/app/models/active_agent/dashboard/agent.rb` — added `requesty` to the `PROVIDERS` list alongside `openrouter`.

## Verification

- `ruby -c` passes ("Syntax OK") on every new/changed `.rb` file.
- `bin/test test/providers/requesty/provider_loading_test.rb` -> 3 runs, 6 assertions, 0 failures, 0 errors. Confirms `RequestyProvider`/`Requesty::Options` load, the provider concern resolves the `Requesty` service to `RequestyProvider`, and options default to the Requesty gateway + `REQUESTY_API_KEY`.
- Existing `test/providers/open_router/transforms_test.rb` and `test/providers/azure/provider_loading_test.rb` still pass (24 runs, 54 assertions, 0 failures) — no regressions.
- Live smoke test against the gateway: `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` returned HTTP **200** with a valid completion.

## Links

- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
