### PR TITLE
Fix: Mock provider raises UnknownAttributeError when response_format is passed 

### DIFF
--- a/lib/active_agent/providers/mock/request.rb
+++ b/lib/active_agent/providers/mock/request.rb
@@ -22,15 +22,12 @@ module ActiveAgent
         attribute :stream, :boolean, default: false
         attribute :tools # Array of tool definitions
         attribute :tool_choice # Tool choice configuration
+        attribute :response_format
 
         # Common Format Compatibility
         def message=(value)
           self.messages ||= []
           self.messages << value
-        end
-
-        def response_format
-          { type: "text" }
         end
       end
     end


### PR DESCRIPTION
## Summary

Fix `ActiveModel::UnknownAttributeError` raised when `response_format` is passed to the Mock provider.

## Steps to Reproduce

```ruby
class MockAgent < ApplicationAgent
  generate_with :mock

  # @return [ActiveAgent::Generation]
  def ask
    prompt(
      message: params[:message],
      response_format: :json_object
    )
  end
end

MockAgent.with(message: "What is ActiveAgent?").ask.generate_now

unknown attribute 'response_format' for ActiveAgent::Providers::Mock::Request. (ActiveModel::UnknownAttributeError)
      raise UnknownAttributeError.new(self, name)
      ^^^^^

```
## Problem

The Mock provider documentation states that `response_format` is "accepted but not validated or enforced", but in practice passing it caused a crash.

The root cause was that `Mock::Request` had a hardcoded getter method but no `attribute :response_format` declaration.
When `BaseProvider` cast the context hash into the request object, ActiveModel tried to call response_format= as a
setter, which didn't exist, and raised the error.

```rb
# Before: hardcoded getter only, no setter
def response_format
  { type: "text" }
end
```

## Fix

Add `attribute :response_format` to `Mock::Request` and remove the hardcoded getter. The attribute now accepts any value passed in, while mock behavior remains unchanged — no schema validation or structured output is enforced.

## How to Verify

Run the reproduction steps above and confirm no error is raised.