### PR TITLE
fix: make Agent.prompt/embed generate_later perform correctly

### DIFF
--- a/lib/active_agent/generation_job.rb
+++ b/lib/active_agent/generation_job.rb
@@ -18,7 +18,19 @@ module ActiveAgent
 
     rescue_from StandardError, with: :handle_exception_with_agent_class
 
-    def perform(agent, agent_method, generation_method, args:, kwargs: nil, params: nil)
+    def perform(agent, agent_method, generation_method, args:, kwargs: nil, params: nil,
+                direct_generation_type: nil, direct_args: nil, direct_options: nil)
+      if direct_generation_type
+        generation = ActiveAgent::Parameterized::DirectGeneration.new(
+          agent.constantize,
+          direct_generation_type.to_sym,
+          params || {},
+          *Array(direct_args),
+          **(direct_options || {}).to_h.deep_symbolize_keys
+        )
+        return generation.send(generation_method)
+      end
+
       agent_class = params ? agent.constantize.with(params) : agent.constantize
       prompt = if kwargs
         agent_class.public_send(agent_method, *args, **kwargs)

--- a/test/features/parameterized_direct_test.rb
+++ b/test/features/parameterized_direct_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ParameterizedDirectTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   class TestAgent < ActiveAgent::Base
     generate_with :mock, model: "mock-model", instructions: "You are a helpful assistant."
     embed_with :mock, model: "mock-embedding-model"
@@ -107,6 +109,14 @@ class ParameterizedDirectTest < ActiveSupport::TestCase
     assert_equal({ queue: :prompts, priority: :high }, generation.enqueue_options)
   end
 
+  test "Agent.prompt(...).generate_later performs the job" do
+    assert_nothing_raised do
+      perform_enqueued_jobs only: ActiveAgent::GenerationJob do
+        TestAgent.prompt(message: "Background task").generate_later
+      end
+    end
+  end
+
   test "Agent.embed returns a generation proxy" do
     generation = TestAgent.embed(input: "Text to embed")
 
@@ -210,6 +220,14 @@ class ParameterizedDirectTest < ActiveSupport::TestCase
     assert generation.enqueue_called?
     assert_equal :embed_now, generation.enqueue_method
     assert_equal({ queue: :embeddings, priority: :low }, generation.enqueue_options)
+  end
+
+  test "Agent.embed(...).embed_later performs the job" do
+    assert_nothing_raised do
+      perform_enqueued_jobs only: ActiveAgent::GenerationJob do
+        TestAgent.embed(input: "Background embedding").embed_later
+      end
+    end
   end
 
   test "prompt() works alongside existing with() method" do


### PR DESCRIPTION
## Summary

Fixes `Agent.prompt(...).generate_later` and `Agent.embed(...).embed_later` crashing when the job runs. `GenerationJob` now accepts the direct generation kwargs and rebuilds `DirectGeneration` instead of calling a fake `__direct_*__` action.

Closes #346

## Test plan

- [ ] `bundle exec ruby bin/test test/features/parameterized_direct_test.rb -n "/performs the job/"`
- [ ] Confirm `Agent.prompt(message: "...").generate_later` performs without `ArgumentError`
- [ ] Confirm `Agent.embed(input: "...").embed_later` performs without `ArgumentError`
