### PR TITLE
Agent-as-tool delegation as a core primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 | Base agent class | `lib/active_agent/base.rb` |
 | Provider implementations | `lib/active_agent/providers/` |
 | Agent concerns/mixins | `lib/active_agent/concerns/` |
+| Agent-as-tool delegation | `lib/active_agent/delegation/` |
 | Rails generators | `lib/generators/active_agent/` |
 | Test suite | `test/` |
 | Test Rails app | `test/dummy/` |
@@ -165,6 +166,58 @@ class MyAgent < ApplicationAgent
 end
 ```
 
+### Delegating to Another Agent (Agent-as-Tool)
+
+When the work behind a tool is itself an AI task, expose a sub-agent instead of a
+plain method. The sub-agent declares its own contract; the caller decides what it
+may spend and what runs it:
+
+```ruby
+class SummarizerAgent < ApplicationAgent
+  generate_with :openai, model: "gpt-4o-mini"
+
+  delegation :summarize, description: "Condense a document into key points" do
+    string  :text, required: true, description: "Full document text"
+    integer :limit, description: "Maximum number of key points"
+
+    returns do                      # optional: becomes the sub-agent's response_format
+      string :summary, required: true
+      array  :points, of: :string, required: true
+    end
+  end
+
+  def summarize(text:, limit: 5)
+    prompt(message: "Summarize in #{limit} points: #{text}")
+  end
+end
+
+class ResearchAgent < ApplicationAgent
+  generate_with :openai, model: "gpt-4o"
+
+  delegation_budget max_calls: 8, max_duration: 60          # all delegations, together
+
+  delegate_to SummarizerAgent, budget: { max_calls: 3, timeout: 20 }
+  delegate_to FactCheckAgent, as: :verify,
+              backend: { provider: :anthropic, model: "claude-haiku-4-5" }
+
+  def research(topic:)
+    prompt(message: "Research #{topic}. Summarize sources before citing them.")
+  end
+end
+```
+
+Key points:
+- `delegate_to` defines a real instance method, so `agent.summarize(text: "...")`
+  runs the delegation directly — handy in tests, no model required.
+- Delegated tools merge into `prompt`'s `tools:` automatically. Scope them per
+  action with `delegations: false` or `delegations: [:summarize]`.
+- Exhausting a budget returns `{ error: "budget_exceeded", ... }` to the calling
+  model by default; pass `on_exceeded: :raise` to fail loudly instead.
+- Swap `backend: :mock` in tests to run a delegation offline with the contract
+  unchanged.
+
+See `docs/actions/delegation.md` and `lib/active_agent/concerns/delegation.rb`.
+
 ### Adding a New Provider
 
 1. Create `lib/active_agent/providers/my_provider.rb`
@@ -238,6 +291,11 @@ bin/test test/integration/open_ai/
 4. **No `tool` macro** - Tools are passed as hashes to `prompt()`, not decorated methods
 5. **Templates use ERB** - Instance variables from agent are available
 6. **Provider config precedence**: Runtime > Agent class > config/active_agent.yml
+7. **Delegations do have a macro** - Unlike tools, sub-agents are declared with
+   `delegation` (on the callee) and `delegate_to` (on the caller); the tool
+   method is generated for you
+8. **Delegation budgets are per generation** - The ledger lives on the agent
+   instance, so there is nothing to reset between requests
 
 ## Useful Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Agent-as-tool delegation
+
+Sub-agents are now a first-class primitive. A tool is a Ruby method your
+model can call; a delegation is another agent your model can call — with
+its own instructions, templates, model and budget.
+
+- **`delegation :action, description:`** declares what a sub-agent exposes:
+  a description for the calling model, a JSON Schema for its inputs (block
+  DSL, a plain hash, or any class responding to `to_json_schema`), and
+  optionally a `returns` schema. A declared `returns` becomes the
+  sub-agent's `response_format`, and its answer is parsed and checked
+  before the caller sees it.
+- **`delegate_to AgentClass`** exposes those contracts to the calling model
+  as tools, with `only:`/`except:`/`as:` for scoping and renaming,
+  `params:` for forwarding, and `action:` for declaring a contract at the
+  call site when you don't own the sub-agent. Per-action scoping via the
+  `delegations:` prompt option.
+- **Cost and latency budgets**: `max_calls`, `max_tokens`, `max_cost`,
+  `max_duration` and a per-call `timeout`, set per delegation and/or
+  agent-wide with `delegation_budget`. Exhausting one returns a structured
+  result the model can act on (`on_exceeded: :stop`, the default) instead
+  of raising mid-conversation; `:raise` is available. Budgets are scoped
+  to a single generation, and spend is readable afterwards via
+  `delegation_ledger`.
+- **Swappable backends**: `backend: :ollama` or
+  `backend: { provider: :anthropic, model: "claude-haiku-4-5" }` moves a
+  delegation to different silicon without touching the sub-agent. Provider
+  swaps rebuild provider configuration rather than merging over it, and
+  template lookup still resolves to the original agent's views.
+- **Cost registry**: `ActiveAgent::Delegation::Pricing.register` records
+  token rates in USD per 1M tokens (no built-in price list, so `max_cost`
+  never fires on stale numbers); rates can also be stated inline on a budget.
+- **Instrumentation**: `delegate.active_agent` (agent, sub-agent, action,
+  model, duration, usage, cost, ledger) and
+  `delegation_refused.active_agent` (violated limit).
+- **New docs** (`docs/actions/delegation.md`) with a worked support-triage
+  example, plus test coverage in `test/features/delegation_test.rb` and
+  `test/docs/actions/delegation_examples_test.rb`.
+
 ### Dashboard & Telemetry — dev console readiness
 
 The dashboard engine — Active Agent's local dev console — now works out of

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ free low-volume trial.
 - **View Templates**: Use ERB templates for prompts (text, JSON, HTML)
 - **Streaming Support**: Real-time response streaming with ActionCable
 - **Tool/Function Calling**: Agents can use tools to interact with external services
+- **Agent-as-Tool Delegation**: Hand work to sub-agents with declared schemas, cost/latency budgets, and swappable backends
 - **Context Management**: Maintain conversation history across interactions
 - **Structured Output**: Define JSON schemas for predictable responses
 
@@ -193,6 +194,29 @@ Agents can use tools to perform actions:
 prompt = SupportAgent.prompt(message: "Show me a cat")
 response = prompt.generate_now
 # Response includes tool call results
+```
+
+### Delegation
+Hand part of a job to a sub-agent, under a declared contract and a budget:
+
+```ruby
+class SummarizerAgent < ApplicationAgent
+  generate_with :openai, model: "gpt-4o-mini"
+
+  delegation :summarize, description: "Condense a document into key points" do
+    string :text, required: true, description: "Full document text"
+  end
+
+  def summarize(text:) = prompt(message: text)
+end
+
+class ResearchAgent < ApplicationAgent
+  generate_with :openai, model: "gpt-4o"
+
+  delegate_to SummarizerAgent, budget: { max_calls: 3, timeout: 20 }
+
+  def research(topic:) = prompt(message: "Research #{topic}")
+end
 ```
 
 ## Learn More

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -121,6 +121,7 @@ export default defineConfig({
           { text: 'Messages', link: '/actions/messages' },
           { text: 'Embeddings', link: '/actions/embeddings' },
           { text: 'Tools', link: '/actions/tools' },
+          { text: 'Delegation', link: '/actions/delegation' },
           { text: 'MCPs', link: '/actions/mcps' },
           { text: 'Structured Output', link: '/actions/structured_output' },
           { text: 'Usage', link: '/actions/usage' },

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -31,6 +31,12 @@ Let AI call Ruby methods during generation:
 
 <<< @/../test/docs/actions_examples_test.rb#tools_weather_agent{ruby:line-numbers}
 
+### [Delegation](/actions/delegation)
+
+Hand part of a job to another agent, under a declared schema and a budget:
+
+<<< @/../test/docs/actions/delegation_examples_test.rb#triage_agent{ruby:line-numbers}
+
 ### [MCPs](/actions/mcps)
 
 Connect to external services via Model Context Protocol:

--- a/docs/actions/delegation.md
+++ b/docs/actions/delegation.md
@@ -1,0 +1,328 @@
+---
+title: Delegation
+description: Agent-as-tool delegation. Hand part of a job to another agent with a declared schema, a cost and latency budget, and a swappable backend.
+---
+# {{ $frontmatter.title }}
+
+A [tool](/actions/tools) is a Ruby method your model can call. A **delegation** is another agent your model can call.
+
+Same mechanism, different unit of work: the callee has its own instructions, its own templates, its own model, and its own budget. That separation is the whole point. A specialist agent stays specialist, and the generalist orchestrating it never inherits its prompt.
+
+## Quick Start
+
+Declare what the sub-agent exposes, then delegate to it:
+
+::: code-group
+<<< @/../test/docs/actions/delegation_examples_test.rb#classifier_agent {ruby:line-numbers} [The sub-agent]
+<<< @/../test/docs/actions/delegation_examples_test.rb#triage_agent {ruby:line-numbers} [The caller]
+:::
+
+`delegate_to` turns every contract the sub-agent declares into a tool. Nothing else changes: the delegated tools sit alongside the action's own `tools:`, and the provider routes calls to them exactly as it routes any other tool call.
+
+## Three Declarations, Three Owners
+
+Delegation has three moving parts, and each is declared where the knowledge actually lives:
+
+| Part | Declared on | Why there |
+|:-----|:------------|:----------|
+| **The contract** — inputs, outputs, description | the sub-agent | It changes when the action changes. Callers never restate it. |
+| **The budget** — calls, tokens, cost, latency | the call site | Only the caller knows what the work is worth. |
+| **The backend** — provider, model, sampling | the call site | The same sub-agent is worth different silicon in different parents. |
+
+## Contracts
+
+`delegation` declares one action: what it accepts, and optionally what it returns.
+
+```ruby
+class TranslatorAgent < ApplicationAgent
+  generate_with :openai, model: "gpt-4o-mini"
+
+  delegation :translate, description: "Translate text into a target language" do
+    string :text, required: true, description: "Text to translate"
+    string :locale, required: true, description: "BCP 47 target locale, e.g. pt-BR"
+  end
+
+  def translate(text:, locale:)
+    prompt(message: "Translate into #{locale}:\n\n#{text}")
+  end
+end
+```
+
+The `description` is the only thing a calling model reads before deciding whether to hand work over. Write it for someone who has never seen the code.
+
+### Schema DSL
+
+Inside a `delegation` block:
+
+```ruby
+delegation :search, description: "Search the product catalogue" do
+  string  :query, required: true, description: "What the customer is looking for"
+  integer :limit, description: "Maximum results (default 10)"
+  number  :max_price, description: "Upper price bound in USD"
+  boolean :in_stock_only
+  string  :sort, enum: %w[relevance price rating], description: "Result ordering"
+
+  array :categories, of: :string, description: "Restrict to these categories"
+
+  array :filters do              # array of objects
+    string :field, required: true
+    string :value, required: true
+  end
+
+  object :shipping do            # nested object
+    string :country, required: true, description: "ISO 3166-1 alpha-2"
+  end
+end
+```
+
+Every keyword you pass beyond `required:` and `description:` lands in the JSON Schema verbatim, so `enum`, `format`, `minimum`, `pattern` and friends all work.
+
+### Reusing an existing schema
+
+A contract can take a JSON Schema hash, or any class that responds to `to_json_schema` — which includes anything using [`ActiveAgent::SchemaGenerator`](/actions/structured_output):
+
+```ruby
+delegation :create, description: "Draft a support ticket", schema: TicketForm
+delegation :notify, description: "Send a notification", schema: {
+  type: "object",
+  properties: { channel: { type: "string" } },
+  required: [ "channel" ]
+}
+```
+
+### Declared outputs
+
+`returns` declares the shape the action answers with. ActiveAgent turns it into the sub-agent's `response_format`, parses the answer, and checks the required keys before handing it back — so the calling agent receives data, not a blob of text it has to re-parse.
+
+```ruby
+delegation :classify, description: "Classify a support ticket by topic and urgency" do
+  string :body, required: true, description: "The customer's message, verbatim"
+
+  returns do
+    string :category, required: true, enum: %w[billing bug account other]
+    string :urgency, required: true, enum: %w[low normal high]
+  end
+end
+```
+
+The delegated call now returns `{ category: "billing", urgency: "high" }`.
+
+When the model returns something that misses a required key, the caller gets a structured `invalid_result` it can act on rather than an exception:
+
+```ruby
+{ error: "invalid_result", missing: [ "urgency" ], message: "...", content: "..." }
+```
+
+Pass `on_invalid: :raise` to the contract if you would rather the generation fail loudly.
+
+### Delegating to an agent you do not own
+
+Declare the contract at the call site instead:
+
+```ruby
+delegate_to Vendor::ClassifierAgent, action: :classify,
+            description: "Classify a support ticket" do
+  string :body, required: true, description: "Ticket body"
+end
+```
+
+## Budgets
+
+A sub-agent is a loop inside a loop. The parent model decides how often to call it, and each call spends tokens and wall-clock time nobody explicitly authorized. A budget puts a ceiling on that.
+
+```ruby
+delegation_budget max_calls: 6, max_duration: 45          # every delegation, together
+
+delegate_to TicketClassifierAgent, budget: { max_calls: 1, timeout: 10 }
+delegate_to KnowledgeBaseAgent, budget: { max_calls: 3, max_tokens: 20_000 }
+```
+
+Both apply — a call has to clear the agent-wide ceiling *and* its own limit.
+
+<!-- @include: @/parts/examples/delegation-examples-test.rb-test-budgets-layer:-the-agent-wide-ceiling-and-the-per-delegation-limit.md -->
+
+| Limit | Unit | Meaning |
+|:------|:-----|:--------|
+| `max_calls` | count | Delegated invocations |
+| `max_tokens` | tokens | Cumulative tokens the sub-agent spent |
+| `max_cost` | USD | Cumulative spend — needs [rates](#cost-budgets) |
+| `max_duration` | seconds | Cumulative wall-clock across delegated calls |
+| `timeout` | seconds | Wall-clock ceiling for a **single** call |
+| `on_exceeded` | `:stop` / `:raise` | What happens at the ceiling |
+| `rates` | hash | Inline token prices for `max_cost` |
+
+Budgets are scoped to one generation. The ledger lives on the agent instance, which ActiveAgent creates fresh for every generation, so there is nothing to reset and no cross-request bleed.
+
+### Exhausting a budget
+
+By default (`on_exceeded: :stop`), the delegation stops and the calling model is told why, in terms it can act on:
+
+<!-- @include: @/parts/examples/delegation-examples-test.rb-test-an-exhausted-budget-answers-the-model-instead-of-raising-at-it.md -->
+
+The generation keeps going and the model answers with what it already has. That is almost always what you want: a bounded answer beats a raised exception halfway through a conversation.
+
+When you would rather fail loudly, `on_exceeded: :raise` raises `ActiveAgent::Delegation::BudgetExceededError`, which carries the violated limit:
+
+```ruby
+delegate_to KnowledgeBaseAgent, budget: { max_calls: 3, on_exceeded: :raise }
+
+rescue ActiveAgent::Delegation::BudgetExceededError => error
+  error.violation.limit    #=> :max_calls
+  error.violation.allowed  #=> 3
+  error.violation.used     #=> 3
+```
+
+Since token spend can only be measured after a call, limits are checked *before* each call: `max_tokens: 8_000` means "stop delegating once 8,000 tokens have been spent", not "never exceed 8,000 tokens".
+
+### Cost budgets
+
+ActiveAgent ships no built-in price list — vendor pricing moves faster than gem releases, and a stale table silently under-reports spend. Register the rates you actually pay, in USD per one million tokens:
+
+```ruby
+# config/initializers/active_agent.rb
+ActiveAgent::Delegation::Pricing.register("gpt-4o-mini", input: 0.15, output: 0.60)
+ActiveAgent::Delegation::Pricing.register(/\Aclaude-haiku/, input: 1.00, output: 5.00)
+```
+
+String patterns match by prefix, so `"gpt-4o-mini"` also covers `"gpt-4o-mini-2024-07-18"`. Or state rates on a single budget:
+
+```ruby
+delegate_to SummarizerAgent, budget: { max_cost: 0.05, rates: { input: 0.15, output: 0.60 } }
+```
+
+A model with no known rates contributes `0.0` to the cost ledger rather than a guess, so `max_cost` never fires on invented numbers.
+
+### Inspecting spend
+
+Every ledger is readable after a generation:
+
+```ruby
+agent = TriageAgent.new
+agent.process(:triage, ticket: ticket)
+agent.process_prompt
+
+agent.delegation_ledger.to_h                #=> { calls: 3, tokens: 4_120, cost: 0.0009, duration: 5.2 }
+agent.delegation_ledger_for(:classify).to_h #=> { calls: 1, tokens: 380, cost: 0.0001, duration: 0.7 }
+```
+
+## Swappable Backends
+
+A sub-agent's contract is separate from what serves it. The same agent can run on a small local model inside one parent and a frontier model inside another — and neither agent's code changes when you move it.
+
+<<< @/../test/docs/actions/delegation_examples_test.rb#backend_swap {ruby:line-numbers}
+
+```ruby
+delegate_to SummarizerAgent, backend: { model: "gpt-4o-mini", temperature: 0 }  # same provider
+delegate_to SummarizerAgent, backend: :ollama                                   # different provider
+delegate_to SummarizerAgent, backend: { provider: :anthropic, model: "claude-haiku-4-5" }
+```
+
+Changing the provider rebuilds provider configuration — host, credentials, service — rather than merging a hash over the old one, so nothing leaks between vendors. Template lookup still resolves to the original agent's views.
+
+Backend options are applied after the sub-agent's own action runs, so the call site wins. That matches ActiveAgent's precedence everywhere else: **runtime > agent class > `config/active_agent.yml`**.
+
+## Scoping Delegations Per Action
+
+By default every declared delegation is offered on every action. Narrow it with the `delegations:` prompt option:
+
+```ruby
+def triage(ticket:)
+  prompt(message: ticket)                                 # every delegation
+end
+
+def acknowledge(ticket:)
+  prompt(message: ticket, delegations: false)             # none — just answer
+end
+
+def route(ticket:)
+  prompt(message: ticket, delegations: [ :classify ])     # one
+end
+```
+
+## Testing Delegations
+
+Two properties make delegations easy to test.
+
+**They are ordinary methods.** `delegate_to` defines a real instance method, so you can call one directly with no model in the loop:
+
+<<< @/../test/docs/actions/delegation_examples_test.rb#testing_call {ruby:line-numbers}
+
+**The backend is swappable.** Point a sub-agent at the [Mock provider](/providers/mock) in tests and the contract stays exactly as production has it:
+
+<<< @/../test/docs/actions/delegation_examples_test.rb#testing_backend {ruby:line-numbers}
+
+<!-- @include: @/parts/examples/delegation-examples-test.rb-test-a-delegation-is-an-ordinary-method,-so-tests-can-call-it-without-a-model.md -->
+
+And what the calling model actually sees is plain data you can assert on:
+
+<!-- @include: @/parts/examples/delegation-examples-test.rb-test-the-sub-agents'-declared-schemas-are-what-the-triage-model-sees.md -->
+
+## Instrumentation
+
+Every delegated call emits `delegate.active_agent` with the agent, sub-agent, action, tool name, arguments, resolved model, duration, usage, cost and the running ledger. Refusals emit `delegation_refused.active_agent` with the violated limit.
+
+```ruby
+ActiveSupport::Notifications.subscribe("delegate.active_agent") do |*, payload|
+  Rails.logger.info(
+    "#{payload[:agent]} → #{payload[:delegate]}##{payload[:action]} " \
+    "#{payload[:duration_ms]}ms #{payload[:usage]&.total_tokens} tokens"
+  )
+end
+```
+
+See [Instrumentation](/framework/instrumentation) for the full event catalogue.
+
+## Provider Support
+
+Delegation is built on function calling, so it works wherever [tools](/actions/tools#provider-support-matrix) do. Declared `returns` schemas additionally use [structured output](/actions/structured_output#provider-support), which is better supported on some providers than others — a contract whose provider ignores `response_format` still validates the parsed answer and reports `invalid_result` when it does not fit.
+
+## Reference
+
+### `delegation`
+
+| Option | Type | Purpose |
+|:-------|:-----|:--------|
+| `description:` | String | **Required.** What the action does, for the calling model |
+| `schema:` | Hash, Class, Schema | Inputs, when not using the block DSL |
+| `returns:` | Hash, Class, Schema | Declared output shape |
+| `budget:` | Hash | Default budget callers inherit |
+| `on_invalid:` | `:error` / `:raise` | When output misses required keys |
+
+### `delegate_to`
+
+| Option | Type | Purpose |
+|:-------|:-----|:--------|
+| `only:` / `except:` | Symbol, Array | Which of the sub-agent's contracts to expose |
+| `as:` | Symbol | Rename the tool the model sees |
+| `action:` | Symbol | Declare a contract here instead of on the sub-agent |
+| `description:` / `schema:` / `returns:` | — | Inline contract, used with `action:` |
+| `backend:` | Symbol, Hash | Provider and options this delegation runs on |
+| `budget:` | Hash | Limits for this delegation |
+| `params:` | Hash, Symbol, Proc | Params forwarded to the sub-agent |
+
+`params:` accepts a Hash, the name of a method on the delegating agent, or a Proc evaluated against it:
+
+```ruby
+delegate_to KnowledgeBaseAgent, params: { locale: "en" }
+delegate_to KnowledgeBaseAgent, params: :knowledge_base_params
+delegate_to KnowledgeBaseAgent, params: -> { { account_id: params[:account_id] } }
+```
+
+## Troubleshooting
+
+**The model never delegates.** The description is the only thing it reads. Say what the sub-agent does and when to use it, not what it is. `tool_choice: "required"` forces a hand-off.
+
+**`already responds to #name`.** The tool name collides with an existing method on the delegating agent. Rename it with `as:`.
+
+**`does not declare any delegations`.** The sub-agent has no `delegation` macro. Add one to it, or declare the contract at the call site with `action:`.
+
+**Arguments the model invented are dropped.** Anything outside the declared schema is discarded before the sub-agent's method is called, so a hallucinated key produces a working call rather than an `ArgumentError`. If a real parameter is being dropped, it is missing from the contract.
+
+## Related Documentation
+
+- [Tools](/actions/tools) — the function-calling layer delegation is built on
+- [Structured Output](/actions/structured_output) — how declared `returns` schemas reach the provider
+- [Instrumentation](/framework/instrumentation) — subscribing to delegation events
+- [Mock Provider](/providers/mock) — running delegations offline in tests
+- [Generation](/agents/generation) — executing delegation-enabled generations
+- [Configuration](/framework/configuration) — provider configuration backends resolve against

--- a/docs/actions/tools.md
+++ b/docs/actions/tools.md
@@ -144,8 +144,21 @@ If the LLM doesn't call your function when expected, improve the tool descriptio
 
 If the LLM passes unexpected parameters, add detailed parameter descriptions with `enum` for restricted choices and mark required parameters explicitly.
 
+## Delegating to Another Agent
+
+When the work behind a tool is itself an AI task — summarizing, classifying, translating — reach for [delegation](/actions/delegation) instead of a plain function. A delegated sub-agent keeps its own instructions, templates and model, and runs under a declared schema, a cost/latency budget, and a swappable backend:
+
+```ruby
+class TriageAgent < ApplicationAgent
+  delegation_budget max_calls: 6, max_duration: 45
+
+  delegate_to TicketClassifierAgent, budget: { max_calls: 1, timeout: 10 }
+end
+```
+
 ## Related Documentation
 
+- [Delegation](/actions/delegation) - Expose another agent to your model as a tool
 - [MCP (Model Context Protocol)](/actions/mcps) - Connect to external services via MCP
 - [Agents](/agents) - Understand the agent lifecycle and callbacks
 - [Generation](/agents/generation) - Execute tool-enabled generations

--- a/lib/active_agent.rb
+++ b/lib/active_agent.rb
@@ -97,6 +97,7 @@ module ActiveAgent
   # These components are loaded on-demand when first referenced.
   autoload :Base
   autoload :Callbacks, "active_agent/concerns/callbacks"
+  autoload :Delegation, "active_agent/concerns/delegation"
   autoload :Streaming, "active_agent/concerns/streaming"
   autoload :InlinePreviewInterceptor
   autoload :Generation

--- a/lib/active_agent/base.rb
+++ b/lib/active_agent/base.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/module/anonymous"
 require "active_support/core_ext/string/inflections"
 
 require "active_agent/concerns/callbacks"
+require "active_agent/concerns/delegation"
 require "active_agent/concerns/observers"
 require "active_agent/concerns/parameterized"
 require "active_agent/concerns/preview"
@@ -42,6 +43,7 @@ module ActiveAgent
     include AbstractController::Caching
 
     include Callbacks
+    include Delegation
     include Parameterized
     include Provider
     include Queueing
@@ -299,18 +301,25 @@ module ActiveAgent
 
     # @api private
     def prepare_prompt_parameters
-      parameters = prompt_options.deep_dup.except(:locals, *PROTECTED_OPTIONS)
+      parameters = prompt_options.deep_dup.except(:locals, :delegations, *PROTECTED_OPTIONS)
 
       # Render out proc/lamda attributes before rendering templates
       parameters.deep_transform_values! { _1.respond_to?(:call) ? _1.call : _1 }
+
+      # Expose declared sub-agents (agent-as-tool) alongside the action's own tools
+      parameters = apply_delegated_tools(parameters, prompt_options)
 
       # Strip parameters the target model rejects (e.g. temperature/top_p
       # on thinking-first models) before they reach the provider.
       ModelCapabilities.sanitize!(parameters)
 
       # Apply Callbacks
+      #
+      # The trace id is written back so it stays stable for the generation and
+      # readable from prompt_options — delegated sub-agents inherit it, which
+      # is what lets a delegation tree show up as one trace.
       parameters.merge!(
-        trace_id: prompt_options[:trace_id] || SecureRandom.uuid,
+        trace_id: prompt_options[:trace_id] ||= SecureRandom.uuid,
         exception_handler:,
         stream_broadcaster:,
         tools_function:,

--- a/lib/active_agent/concerns/delegation.rb
+++ b/lib/active_agent/concerns/delegation.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require "active_agent/delegation/schema"
+require "active_agent/delegation/pricing"
+require "active_agent/delegation/budget"
+require "active_agent/delegation/ledger"
+require "active_agent/delegation/backend"
+require "active_agent/delegation/contract"
+require "active_agent/delegation/definition"
+require "active_agent/delegation/runner"
+
+module ActiveAgent
+  # Agent-as-tool delegation: hand part of a job to another agent.
+  #
+  # A tool is a Ruby method the model can call. A *delegation* is another agent
+  # the model can call — same mechanism, but the callee has its own
+  # instructions, its own templates, its own model, and its own budget. That
+  # separation is what makes the pattern worth having as a primitive: a
+  # specialist agent stays specialist, and the generalist orchestrating it
+  # never inherits its prompt.
+  #
+  # Delegation has three moving parts, each declared where it belongs:
+  #
+  # * **The contract** lives on the sub-agent, next to the action it describes.
+  #   Callers say which agent they want; they never restate its parameters.
+  # * **The budget** lives at the call site, because only the caller knows what
+  #   the work is worth. Exceeding it returns a structured result the model can
+  #   reason about, not an exception that ends the conversation.
+  # * **The backend** lives at the call site too, so the same sub-agent can run
+  #   on a cheap local model in one parent and a frontier model in another
+  #   without either agent's code changing.
+  #
+  # @example Declaring a sub-agent's contract
+  #   class SummarizerAgent < ApplicationAgent
+  #     generate_with :openai, model: "gpt-4o-mini"
+  #
+  #     delegation :summarize, description: "Condense a document into key points" do
+  #       string  :text, required: true, description: "Full document text"
+  #       integer :limit, description: "Maximum number of key points to return"
+  #
+  #       returns do
+  #         string :summary, required: true, description: "One-paragraph summary"
+  #         array  :points, of: :string, required: true, description: "The key points"
+  #       end
+  #     end
+  #
+  #     def summarize(text:, limit: 5)
+  #       prompt(message: text, limit: limit)
+  #     end
+  #   end
+  #
+  # @example Delegating to it
+  #   class ResearchAgent < ApplicationAgent
+  #     generate_with :openai, model: "gpt-4o"
+  #
+  #     delegation_budget max_calls: 8, max_duration: 60
+  #
+  #     delegate_to SummarizerAgent, budget: { max_calls: 3, timeout: 20 }
+  #     delegate_to FactCheckAgent, as: :verify, backend: { provider: :anthropic, model: "claude-haiku-4-5" }
+  #
+  #     def research(topic:)
+  #       prompt(message: "Research #{topic}. Summarize sources before citing them.")
+  #     end
+  #   end
+  #
+  # @see ActiveAgent::Delegation::Contract
+  # @see ActiveAgent::Delegation::Budget
+  # @see ActiveAgent::Delegation::Backend
+  module Delegation
+    extend ActiveSupport::Concern
+
+    # Raised when a delegation budget is exhausted and the policy is +:raise+.
+    class BudgetExceededError < StandardError
+      # @return [Budget::Violation]
+      attr_reader :violation
+      # @return [Definition]
+      attr_reader :definition
+
+      def initialize(violation, definition:)
+        @violation  = violation
+        @definition = definition
+
+        super("#{definition.agent_class}##{definition.action} exceeded its delegation budget " \
+              "(#{violation.limit}: #{violation.used} of #{violation.allowed} used)")
+      end
+    end
+
+    # Raised when a delegated call exceeds its timeout and the policy is +:raise+.
+    class TimeoutError < StandardError; end
+
+    # Raised when a sub-agent's output does not satisfy its declared +returns+
+    # schema and the policy is +:raise+.
+    class InvalidResultError < StandardError; end
+
+    included do
+      # Contracts this agent exposes to callers, keyed by action.
+      class_attribute :delegation_contracts, instance_accessor: false, default: {}.freeze
+
+      # Sub-agents this agent delegates to, keyed by tool name.
+      class_attribute :delegations, instance_accessor: false, default: {}.freeze
+
+      # Budget covering *all* delegated work in one generation.
+      class_attribute :_delegation_budget, instance_accessor: false, default: Budget.new
+    end
+
+    class_methods do
+      # Declares what this agent exposes to callers: one action, its inputs,
+      # and optionally the shape of what it returns.
+      #
+      # The description is the only thing a calling model reads before deciding
+      # whether to hand work over — write it for someone who has never seen the
+      # code.
+      #
+      # @param action [Symbol, String] the action a caller invokes
+      # @param description [String] what the action does
+      # @param schema [Hash, Class, Delegation::Schema, nil] inputs, when not using the block DSL
+      # @param returns [Hash, Class, Delegation::Schema, nil] declared output shape
+      # @param budget [Hash, Delegation::Budget, nil] default budget callers inherit
+      # @param on_invalid [Symbol] +:error+ (default) or +:raise+ when output misses required keys
+      # @yield input DSL; call +returns+ inside it to declare the output shape
+      # @return [Delegation::Contract]
+      #
+      # @example
+      #   delegation :translate, description: "Translate text into a target language" do
+      #     string :text, required: true, description: "Text to translate"
+      #     string :locale, required: true, description: "BCP 47 target locale, e.g. pt-BR"
+      #   end
+      def delegation(action, description: nil, schema: nil, returns: nil, budget: nil, on_invalid: :error, &block)
+        contract = Delegation::Contract.new(
+          action: action, description: description, schema: schema,
+          returns: returns, budget: budget, on_invalid: on_invalid, &block
+        )
+
+        self.delegation_contracts = delegation_contracts.merge(contract.action => contract).freeze
+
+        contract
+      end
+
+      # Exposes another agent to this agent's model as a tool.
+      #
+      # With no options, every contract the sub-agent declares becomes a tool.
+      # Narrow that with +only:+/+except:+, rename with +as:+, or declare a
+      # contract inline with +action:+ when you don't own the sub-agent.
+      #
+      # @param agent_class [Class] the sub-agent
+      # @param only [Symbol, Array<Symbol>, nil] expose just these actions
+      # @param except [Symbol, Array<Symbol>, nil] expose everything but these actions
+      # @param as [Symbol, String, nil] tool name (defaults to the action name)
+      # @param action [Symbol, String, nil] declare a contract inline for this action
+      # @param description [String, nil] overrides the contract's description
+      # @param schema [Hash, Class, Delegation::Schema, nil] inline contract inputs
+      # @param returns [Hash, Class, Delegation::Schema, nil] inline contract outputs
+      # @param backend [Symbol, Hash, Delegation::Backend, nil] provider/model to run this delegation on
+      # @param budget [Hash, Delegation::Budget, nil] limits for this delegation
+      # @param params [Hash, Symbol, Proc, nil] params forwarded to the sub-agent
+      # @yield inline contract input DSL
+      # @return [Array<Delegation::Definition>]
+      # @raise [ArgumentError] on an unknown action, a name collision, or a sub-agent with no contracts
+      #
+      # @example Everything the sub-agent declares
+      #   delegate_to SummarizerAgent
+      #
+      # @example One action, renamed, on a different backend, with a budget
+      #   delegate_to SummarizerAgent, only: :summarize, as: :condense,
+      #               backend: { model: "gpt-4o-mini" }, budget: { max_calls: 3 }
+      #
+      # @example An agent you don't own, described from here
+      #   delegate_to Vendor::ClassifierAgent, action: :classify,
+      #               description: "Classify a support ticket" do
+      #     string :body, required: true, description: "Ticket body"
+      #   end
+      def delegate_to(agent_class, only: nil, except: nil, as: nil, action: nil, description: nil,
+                      schema: nil, returns: nil, backend: nil, budget: nil, params: nil, &block)
+        contracts = delegation_contracts_for(agent_class, action:, only:, except:, description:, schema:, returns:, &block)
+
+        if (as || description) && contracts.size > 1
+          raise ArgumentError, "`as:` and `description:` describe a single delegation, but #{agent_class} exposes " \
+            "#{contracts.size} (#{contracts.map(&:action).join(", ")}). Narrow it with `only:` first."
+        end
+
+        contracts.map do |contract|
+          define_delegation Delegation::Definition.new(
+            agent_class: agent_class, contract: contract, tool_name: as,
+            description: description, backend: backend, budget: budget, params: params
+          )
+        end
+      end
+
+      # Budget covering every delegation this agent makes in one generation.
+      #
+      # Per-delegation budgets still apply; a call has to clear both. Called
+      # without arguments it reads the current budget.
+      #
+      # @param limits [Hash] see {Delegation::Budget}
+      # @return [Delegation::Budget]
+      #
+      # @example
+      #   delegation_budget max_calls: 10, max_duration: 60, max_cost: 0.25
+      def delegation_budget(**limits)
+        self._delegation_budget = _delegation_budget.merge(Delegation::Budget.build(limits)) if limits.any?
+
+        _delegation_budget
+      end
+
+      # Tool definitions for this agent's delegations, in the common tools format.
+      #
+      # @param filter [nil, true, false, Symbol, Array<Symbol>] which delegations to include
+      # @return [Array<Hash>]
+      def delegated_tools(filter = nil)
+        delegations_for(filter).map(&:to_tool)
+      end
+
+      # @param filter [nil, true, false, Symbol, Array<Symbol>]
+      # @return [Array<Delegation::Definition>]
+      def delegations_for(filter = nil)
+        case filter
+        when nil, true then delegations.values
+        when false     then []
+        else
+          names = Array(filter).map(&:to_sym)
+          unknown = names - delegations.keys
+          raise ArgumentError, "Unknown #{"delegation".pluralize(unknown.size)}: #{unknown.join(", ")}. " \
+            "This agent delegates to: #{delegations.keys.join(", ").presence || "(none)"}" if unknown.any?
+
+          delegations.values_at(*names)
+        end
+      end
+
+      private
+
+      # Registers a definition and the tool method the provider routes to.
+      #
+      # @param definition [Delegation::Definition]
+      # @return [Delegation::Definition]
+      def define_delegation(definition)
+        assert_available_tool_name!(definition)
+
+        self.delegations = delegations.merge(definition.tool_name => definition).freeze
+
+        tool_name = definition.tool_name
+        define_method(tool_name) do |**arguments|
+          perform_delegation(tool_name, **arguments)
+        end
+
+        definition
+      end
+
+      # @param definition [Delegation::Definition]
+      # @raise [ArgumentError]
+      def assert_available_tool_name!(definition)
+        name = definition.tool_name
+        return if delegations.key?(name) # re-declaring a delegation is a deliberate override
+
+        if method_defined?(name) || private_method_defined?(name)
+          raise ArgumentError, "#{self} already responds to ##{name}, so it cannot also be the tool name for " \
+            "#{definition.agent_class}##{definition.action}. Rename it with `as:`."
+        end
+      end
+
+      # @return [Array<Delegation::Contract>]
+      def delegation_contracts_for(agent_class, action:, only:, except:, description:, schema:, returns:, &block)
+        assert_agent_class!(agent_class)
+
+        if action
+          assert_action!(agent_class, action)
+
+          return [ Delegation::Contract.new(
+            action: action, description: description, schema: schema, returns: returns, &block
+          ) ]
+        end
+
+        contracts = agent_class.delegation_contracts.values
+
+        if contracts.empty?
+          raise ArgumentError, "#{agent_class} does not declare any delegations. Add " \
+            "`delegation :action_name, description: \"...\"` to it, or declare one here with " \
+            "`delegate_to #{agent_class}, action: :action_name, description: \"...\"`."
+        end
+
+        contracts = filter_contracts(contracts, only: only, except: except, agent_class: agent_class)
+        contracts.each { |contract| assert_action!(agent_class, contract.action) }
+        contracts
+      end
+
+      # @return [Array<Delegation::Contract>]
+      def filter_contracts(contracts, only:, except:, agent_class:)
+        selected = contracts
+
+        if only
+          names = Array(only).map(&:to_sym)
+          assert_declared!(agent_class, names, contracts)
+          selected = selected.select { |contract| names.include?(contract.action) }
+        end
+
+        if except
+          names = Array(except).map(&:to_sym)
+          assert_declared!(agent_class, names, contracts)
+          selected = selected.reject { |contract| names.include?(contract.action) }
+        end
+
+        raise ArgumentError, "No delegations left on #{agent_class} after applying only:/except:" if selected.empty?
+
+        selected
+      end
+
+      # @raise [ArgumentError]
+      def assert_declared!(agent_class, names, contracts)
+        unknown = names - contracts.map(&:action)
+        return if unknown.empty?
+
+        raise ArgumentError, "#{agent_class} does not declare #{"delegation".pluralize(unknown.size)} " \
+          "#{unknown.join(", ")}. It declares: #{contracts.map(&:action).join(", ")}"
+      end
+
+      # @raise [ArgumentError]
+      def assert_agent_class!(agent_class)
+        return if agent_class.is_a?(Class) && agent_class < ActiveAgent::Base
+
+        raise ArgumentError, "delegate_to expects an ActiveAgent::Base subclass, got #{agent_class.inspect}"
+      end
+
+      # @raise [ArgumentError]
+      def assert_action!(agent_class, action)
+        return if agent_class.method_defined?(action) || agent_class.private_method_defined?(action)
+
+        raise ArgumentError, "#{agent_class} does not define ##{action}, so it cannot be delegated to."
+      end
+    end
+
+    # Ledger covering every delegation made during this generation.
+    #
+    # @return [Delegation::Ledger]
+    def delegation_ledger
+      @_delegation_ledger ||= Delegation::Ledger.new
+    end
+
+    # Ledger for a single delegation during this generation.
+    #
+    # @param tool_name [Symbol, String]
+    # @return [Delegation::Ledger]
+    def delegation_ledger_for(tool_name)
+      delegation_ledgers[tool_name.to_sym] ||= Delegation::Ledger.new
+    end
+
+    # @return [Hash{Symbol => Delegation::Ledger}] per-delegation ledgers
+    def delegation_ledgers
+      @_delegation_ledgers ||= {}
+    end
+
+    # Runs a delegated call. Providers reach this through the tool method
+    # {ClassMethods#delegate_to} defines.
+    #
+    # @param tool_name [Symbol, String]
+    # @param arguments [Hash]
+    # @return [Object]
+    def perform_delegation(tool_name, **arguments)
+      definition = self.class.delegations[tool_name.to_sym]
+      raise ArgumentError, "#{self.class} has no delegation named #{tool_name}" unless definition
+
+      Delegation::Runner.new(definition, owner: self).call(**arguments)
+    end
+
+    private
+
+    # Merges declared delegations into the tools the provider is given.
+    #
+    # Scope them per action with the +delegations:+ prompt option: +false+ for
+    # none, or a name/list for a subset.
+    #
+    # @param parameters [Hash]
+    # @param prompt_options [Hash]
+    # @return [Hash]
+    # @api private
+    def apply_delegated_tools(parameters, prompt_options)
+      tools = self.class.delegated_tools(prompt_options[:delegations])
+      return parameters if tools.empty?
+
+      declared = Array(parameters[:tools])
+      names    = declared.filter_map { |tool| (tool[:name] || tool["name"]).to_s if tool.is_a?(Hash) }
+
+      parameters[:tools] = declared + tools.reject { |tool| names.include?(tool[:name]) }
+      parameters
+    end
+  end
+end

--- a/lib/active_agent/delegation/backend.rb
+++ b/lib/active_agent/delegation/backend.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Delegation
+    # The provider and options a delegated call runs against.
+    #
+    # A sub-agent's contract — what it accepts, what it returns — is separate
+    # from what actually serves it. Backend is that seam: the same
+    # +SummarizerAgent+ can run on a cheap local model inside one parent and on
+    # a frontier model inside another, and neither parent's code changes when
+    # you move it.
+    #
+    # @example Swap the model, keep the provider
+    #   delegate_to SummarizerAgent, backend: { model: "gpt-4o-mini", temperature: 0 }
+    #
+    # @example Swap the provider entirely
+    #   delegate_to SummarizerAgent, backend: :ollama
+    #
+    # @example Swap both
+    #   delegate_to SummarizerAgent, backend: { provider: :anthropic, model: "claude-haiku-4-5" }
+    class Backend
+      # @return [Symbol, nil] provider reference (+:openai+, +:anthropic+, ...)
+      attr_reader :provider
+      # @return [Hash] prompt options applied at the call site
+      attr_reader :options
+
+      # @param spec [Backend, Symbol, String, Hash, nil]
+      # @return [Backend]
+      def self.build(spec = nil)
+        case spec
+        when Backend        then spec
+        when nil            then new
+        when Symbol, String then new(provider: spec)
+        when Hash           then new(**spec.symbolize_keys)
+        else
+          raise ArgumentError, "Delegation backend must be a Symbol, Hash or #{name}, got #{spec.inspect}"
+        end
+      end
+
+      # @param provider [Symbol, String, nil]
+      # @param options [Hash] prompt options (model, temperature, ...)
+      def initialize(provider: nil, **options)
+        @provider = provider&.to_sym
+        @options  = options
+        @mutex    = Mutex.new
+      end
+
+      # @return [Boolean] whether this backend changes anything
+      def overrides?
+        provider.present? || options.any?
+      end
+
+      # Resolves the class a delegated call should instantiate.
+      #
+      # Swapping providers means rebuilding provider configuration (host, keys,
+      # service), not just merging a hash — so the swap goes through a cached
+      # subclass configured by +generate_with+, the same code path a
+      # hand-written agent takes. The subclass reports its parent's name so
+      # template lookup keeps resolving to the original agent's views.
+      #
+      # @param agent_class [Class] the declared sub-agent class
+      # @return [Class]
+      def agent_class_for(agent_class)
+        return agent_class if provider.blank?
+
+        @mutex.synchronize do
+          @agent_classes ||= {}
+          @agent_classes[agent_class] ||= build_agent_class(agent_class)
+        end
+      end
+
+      # Applies call-site options to a prepared agent instance.
+      #
+      # Applied after the action has run so the delegation site wins over the
+      # sub-agent's own +prompt+ options — a call-site override is runtime
+      # configuration, which outranks class configuration everywhere else in
+      # ActiveAgent.
+      #
+      # @param agent [ActiveAgent::Base]
+      # @return [ActiveAgent::Base]
+      def apply(agent)
+        agent.prompt_options.merge!(options) if options.any?
+        agent
+      end
+
+      # @return [Hash]
+      def to_h
+        { provider: provider }.compact.merge(options)
+      end
+
+      private
+
+      # @param agent_class [Class]
+      # @return [Class]
+      def build_agent_class(agent_class)
+        backend_provider = provider
+        inherited_name   = agent_class.name
+
+        Class.new(agent_class) do
+          # Keep the parent's identity so `agent_name`, and therefore view
+          # lookup, resolves to the original agent's templates.
+          define_singleton_method(:name) { inherited_name }
+
+          generate_with backend_provider
+        end
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/budget.rb
+++ b/lib/active_agent/delegation/budget.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Delegation
+    # Cost and latency limits for delegated work.
+    #
+    # A sub-agent is a loop inside a loop: the parent model decides how often
+    # to call it, and each call spends tokens and wall-clock time nobody
+    # explicitly authorized. A budget puts a ceiling on that — per delegation
+    # and across the agent as a whole — so a runaway hand-off degrades into a
+    # bounded answer instead of an unbounded bill.
+    #
+    # Every limit is optional; an empty budget imposes nothing.
+    #
+    # @example Per delegation
+    #   delegate_to SummarizerAgent, budget: { max_calls: 3, max_tokens: 8_000, timeout: 20 }
+    #
+    # @example Across every delegation this agent makes
+    #   delegation_budget max_calls: 10, max_duration: 60, max_cost: 0.25,
+    #                     rates: { input: 0.15, output: 0.60 }
+    class Budget
+      # What to do when a limit is reached.
+      #
+      # +:stop+  — return a structured "budget exhausted" result to the calling
+      #            model so it can finish with what it already has (default).
+      # +:raise+ — raise {BudgetExceededError} and abort the generation.
+      POLICIES = %i[stop raise].freeze
+
+      LIMITS = %i[max_calls max_tokens max_cost max_duration].freeze
+      KEYS   = (LIMITS + %i[timeout rates on_exceeded]).freeze
+
+      # A limit that has been reached.
+      Violation = Struct.new(:limit, :allowed, :used, keyword_init: true) do
+        # @return [String] wording aimed at the calling model, not at a developer
+        def message
+          "Delegation budget exhausted (#{limit}: #{format_number(used)} of #{format_number(allowed)} used). " \
+            "Do not retry this tool; answer with the information you already have."
+        end
+
+        private
+
+        def format_number(value)
+          value.is_a?(Float) ? value.round(6) : value
+        end
+      end
+
+      # @return [Integer, nil] maximum number of delegated calls
+      attr_reader :max_calls
+      # @return [Integer, nil] maximum cumulative tokens across delegated calls
+      attr_reader :max_tokens
+      # @return [Float, nil] maximum cumulative spend in USD
+      attr_reader :max_cost
+      # @return [Float, nil] maximum cumulative wall-clock seconds
+      attr_reader :max_duration
+      # @return [Float, nil] per-call wall-clock timeout in seconds
+      attr_reader :timeout
+      # @return [Hash, nil] inline token rates in USD per 1M tokens
+      attr_reader :rates
+      # @return [Symbol, nil] :stop or :raise
+      attr_reader :on_exceeded
+
+      # Coerces a budget spec into a Budget.
+      #
+      # @param spec [Budget, Hash, nil]
+      # @return [Budget]
+      # @raise [ArgumentError] on unknown keys or an invalid policy
+      def self.build(spec = nil)
+        case spec
+        when Budget then spec
+        when nil    then new
+        when Hash   then new(**spec.symbolize_keys)
+        else
+          raise ArgumentError, "Delegation budget must be a Hash or #{name}, got #{spec.inspect}"
+        end
+      end
+
+      def initialize(**options)
+        unknown = options.keys - KEYS
+        raise ArgumentError, "Unknown delegation budget keys: #{unknown.join(", ")}. Valid keys: #{KEYS.join(", ")}" if unknown.any?
+
+        @max_calls    = options[:max_calls]
+        @max_tokens   = options[:max_tokens]
+        @max_cost     = options[:max_cost]
+        @max_duration = options[:max_duration]
+        @timeout      = options[:timeout]
+        @rates        = options[:rates]
+        @on_exceeded  = options[:on_exceeded]&.to_sym
+
+        if @on_exceeded && !POLICIES.include?(@on_exceeded)
+          raise ArgumentError, "Unknown delegation budget policy #{@on_exceeded.inspect}. Valid policies: #{POLICIES.join(", ")}"
+        end
+      end
+
+      # Returns a budget where +other+'s settings win over this one's.
+      #
+      # @param other [Budget, nil]
+      # @return [Budget]
+      def merge(other)
+        return self if other.nil?
+
+        self.class.new(**to_h.merge(other.to_h))
+      end
+
+      # @return [Boolean] whether any limit is set
+      def limited?
+        LIMITS.any? { |limit| public_send(limit) }
+      end
+
+      # @return [Symbol] the effective policy
+      def policy
+        on_exceeded || :stop
+      end
+
+      # Finds the first limit the ledger has already reached.
+      #
+      # Limits are checked *before* a call runs, because token spend can only
+      # be measured after the fact. A budget of +max_tokens: 8_000+ therefore
+      # means "stop delegating once 8,000 tokens have been spent", not "never
+      # exceed 8,000 tokens".
+      #
+      # @param ledger [Ledger]
+      # @return [Violation, nil]
+      def violation_for(ledger)
+        return Violation.new(limit: :max_calls,    allowed: max_calls,    used: ledger.calls)    if max_calls    && ledger.calls    >= max_calls
+        return Violation.new(limit: :max_tokens,   allowed: max_tokens,   used: ledger.tokens)   if max_tokens   && ledger.tokens   >= max_tokens
+        return Violation.new(limit: :max_cost,     allowed: max_cost,     used: ledger.cost)     if max_cost     && ledger.cost     >= max_cost
+        return Violation.new(limit: :max_duration, allowed: max_duration, used: ledger.duration) if max_duration && ledger.duration >= max_duration
+
+        nil
+      end
+
+      # @return [Hash] only the settings that were actually provided
+      def to_h
+        KEYS.index_with { |key| public_send(key) }.compact
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/contract.rb
+++ b/lib/active_agent/delegation/contract.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+module ActiveAgent
+  module Delegation
+    # What a sub-agent promises: one action, its inputs, and optionally the
+    # shape of what it returns.
+    #
+    # The contract is declared on the sub-agent itself, next to the action it
+    # describes, so a delegation stays correct when the action changes. Callers
+    # then say only which agent they want — they never restate its parameters.
+    #
+    # @example
+    #   class SummarizerAgent < ApplicationAgent
+    #     delegation :summarize, description: "Condense a document into key points" do
+    #       string  :text, required: true, description: "Full document text"
+    #       integer :limit, description: "Maximum number of key points"
+    #
+    #       returns do
+    #         string :summary, required: true, description: "One-paragraph summary"
+    #         array  :points, of: :string, required: true, description: "Key points"
+    #       end
+    #     end
+    #
+    #     def summarize(text:, limit: 5)
+    #       prompt(message: text, limit: limit)
+    #     end
+    #   end
+    class Contract
+      # What to do when a sub-agent's output does not satisfy its +returns+ schema.
+      #
+      # +:error+ — hand the calling model a structured error so it can retry or
+      #            route around the failure (default).
+      # +:raise+ — raise {InvalidResultError} and abort the generation.
+      INVALID_POLICIES = %i[error raise].freeze
+
+      # @return [Symbol] the sub-agent action this contract describes
+      attr_reader :action
+      # @return [String] what the action does, written for the calling model
+      attr_reader :description
+      # @return [Schema] declared inputs
+      attr_reader :schema
+      # @return [Schema, nil] declared output shape, when the action returns structured data
+      attr_reader :returns
+      # @return [Budget] default budget suggested by the sub-agent
+      attr_reader :budget
+      # @return [Symbol] :error or :raise
+      attr_reader :on_invalid
+
+      # @param action [Symbol, String]
+      # @param description [String]
+      # @param schema [Schema, Hash, Class, nil] inputs, or nil to use the block DSL
+      # @param returns [Schema, Hash, Class, nil] declared output shape
+      # @param budget [Budget, Hash, nil] default budget for callers
+      # @param on_invalid [Symbol] :error or :raise
+      # @yield input DSL; may also call +returns+ to declare the output shape
+      def initialize(action:, description:, schema: nil, returns: nil, budget: nil, on_invalid: :error, &block)
+        @action      = action.to_sym
+        @description = description
+        @returns     = returns && Schema.build(returns)
+        @budget      = Budget.build(budget)
+        @on_invalid  = on_invalid.to_sym
+
+        unless INVALID_POLICIES.include?(@on_invalid)
+          raise ArgumentError, "Unknown delegation on_invalid policy #{@on_invalid.inspect}. " \
+            "Valid policies: #{INVALID_POLICIES.join(", ")}"
+        end
+
+        raise ArgumentError, "A delegation needs a description — it is the only thing the calling model reads" if @description.blank?
+
+        @schema = Schema.build(schema)
+
+        if block
+          dsl = DSL.new(self, @schema)
+          block.arity == 1 ? block.call(dsl) : dsl.instance_eval(&block)
+        end
+      end
+
+      # @return [Boolean]
+      def structured?
+        returns.present?
+      end
+
+      # Sets the declared output shape. Used by the DSL's +returns+ helper.
+      #
+      # @param schema [Schema]
+      # @return [Schema]
+      # @api private
+      def returns=(schema)
+        @returns = schema
+      end
+
+      # Wraps the input schema DSL so that +returns+ inside a delegation block
+      # declares the *output* shape rather than an input property.
+      #
+      # @api private
+      class DSL < SimpleDelegator
+        # @param contract [Contract]
+        # @param schema [Schema]
+        def initialize(contract, schema)
+          @contract = contract
+          super(schema)
+        end
+
+        # Declares the shape the action returns.
+        #
+        # @param source [Schema, Hash, Class, nil]
+        # @yield output DSL
+        # @return [Schema]
+        def returns(source = nil, &block)
+          @contract.returns = Schema.build(source, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/definition.rb
+++ b/lib/active_agent/delegation/definition.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Delegation
+    # A sub-agent bound into a calling agent as a tool.
+    #
+    # Pairs the sub-agent's {Contract} — what it accepts and returns — with the
+    # decisions that belong to the caller: what to call it, what it may spend,
+    # and which backend serves it.
+    class Definition
+      # @return [Class] the sub-agent class
+      attr_reader :agent_class
+      # @return [Contract]
+      attr_reader :contract
+      # @return [Symbol] the tool name exposed to the calling model
+      attr_reader :tool_name
+      # @return [String]
+      attr_reader :description
+      # @return [Backend]
+      attr_reader :backend
+      # @return [Budget]
+      attr_reader :budget
+      # @return [Hash, Symbol, Proc, nil] params forwarded to the sub-agent
+      attr_reader :params
+
+      # @param agent_class [Class]
+      # @param contract [Contract]
+      # @param tool_name [Symbol, String, nil] defaults to the contract's action
+      # @param description [String, nil] overrides the contract's description
+      # @param backend [Backend, Symbol, Hash, nil]
+      # @param budget [Budget, Hash, nil] merged over the contract's default budget
+      # @param params [Hash, Symbol, Proc, nil]
+      def initialize(agent_class:, contract:, tool_name: nil, description: nil, backend: nil, budget: nil, params: nil)
+        @agent_class = agent_class
+        @contract    = contract
+        @tool_name   = (tool_name || contract.action).to_sym
+        @description = description.presence || contract.description
+        @backend     = Backend.build(backend)
+        @budget      = contract.budget.merge(Budget.build(budget))
+        @params      = params
+      end
+
+      # @return [Symbol] the sub-agent action invoked
+      def action = contract.action
+
+      # @return [Schema] declared inputs
+      def schema = contract.schema
+
+      # @return [Schema, nil] declared outputs
+      def returns = contract.returns
+
+      # @return [Boolean]
+      def structured? = contract.structured?
+
+      # @return [Symbol]
+      def on_invalid = contract.on_invalid
+
+      # The class a call actually instantiates, after any backend swap.
+      #
+      # @return [Class]
+      def resolved_agent_class
+        backend.agent_class_for(agent_class)
+      end
+
+      # Tool definition in ActiveAgent's common tools format.
+      #
+      # This is what the calling model sees — the whole point of declaring a
+      # schema rather than describing the sub-agent in prose.
+      #
+      # @return [Hash]
+      def to_tool
+        {
+          name: tool_name.to_s,
+          description: description,
+          parameters: schema.to_json_schema
+        }
+      end
+
+      # Returns a copy with call-site overrides applied.
+      #
+      # @return [Definition]
+      def with(tool_name: nil, description: nil, backend: nil, budget: nil, params: nil)
+        self.class.new(
+          agent_class: agent_class,
+          contract: contract,
+          tool_name: tool_name || self.tool_name,
+          description: description || self.description,
+          backend: backend || self.backend,
+          budget: budget ? self.budget.merge(Budget.build(budget)) : self.budget,
+          params: params || self.params
+        )
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/ledger.rb
+++ b/lib/active_agent/delegation/ledger.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Delegation
+    # Running tally of what delegated work has consumed.
+    #
+    # One ledger is kept per delegation plus one for the agent as a whole, and
+    # both live on the agent instance — which is created fresh for every
+    # generation. A budget is therefore scoped to a single generation and its
+    # entire tool loop, with no cross-request bleed and nothing to reset.
+    #
+    # @example Inspecting spend after a generation
+    #   agent = ResearchAgent.new
+    #   agent.process(:research, topic: "hydrogen storage")
+    #   agent.process_prompt
+    #   agent.delegation_ledger.to_h
+    #   #=> { calls: 2, tokens: 1_840, cost: 0.0004, duration: 3.1 }
+    class Ledger
+      # @return [Integer] delegated calls completed
+      attr_reader :calls
+      # @return [Integer] cumulative total tokens
+      attr_reader :tokens
+      # @return [Float] cumulative USD spend (0.0 when no rates are known)
+      attr_reader :cost
+      # @return [Float] cumulative wall-clock seconds
+      attr_reader :duration
+
+      def initialize
+        @calls    = 0
+        @tokens   = 0
+        @cost     = 0.0
+        @duration = 0.0
+      end
+
+      # Records one delegated call.
+      #
+      # @param tokens [Integer, nil]
+      # @param cost [Float, nil] nil when the model's rates are unknown
+      # @param duration [Float] seconds
+      # @return [self]
+      def record(tokens: 0, cost: nil, duration: 0.0)
+        @calls    += 1
+        @tokens   += tokens.to_i
+        @cost     += cost.to_f
+        @duration += duration.to_f
+
+        self
+      end
+
+      # @return [Hash]
+      def to_h
+        { calls: calls, tokens: tokens, cost: cost, duration: duration }
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/pricing.rb
+++ b/lib/active_agent/delegation/pricing.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Delegation
+    # Token price registry used to turn usage into dollars for cost budgets.
+    #
+    # ActiveAgent deliberately ships no built-in price list: vendor pricing
+    # changes far faster than a gem release, and a stale table silently
+    # under-reports spend. Register the rates your app actually pays — once,
+    # in an initializer — and every cost budget in the app uses them.
+    #
+    # Rates are expressed in **USD per one million tokens**, matching how
+    # every major provider publishes them.
+    #
+    # @example Register rates for the models you use
+    #   # config/initializers/active_agent.rb
+    #   ActiveAgent::Delegation::Pricing.register("gpt-4o-mini", input: 0.15, output: 0.60)
+    #   ActiveAgent::Delegation::Pricing.register(/\Aclaude-haiku/, input: 1.00, output: 5.00)
+    #
+    # @example Or state rates inline on a single budget
+    #   delegate_to SummarizerAgent, budget: { max_cost: 0.05, rates: { input: 0.15, output: 0.60 } }
+    module Pricing
+      # A registered rate card.
+      Rate = Struct.new(:pattern, :input, :output, keyword_init: true) do
+        # @param model [String]
+        # @return [Boolean]
+        def matches?(model)
+          case pattern
+          when Regexp then pattern.match?(model)
+          else model.to_s.start_with?(pattern.to_s)
+          end
+        end
+      end
+
+      class << self
+        # @return [Array<Rate>] registered rates, most recently registered first
+        def rates
+          @rates ||= []
+        end
+
+        # Registers a rate card.
+        #
+        # String patterns match by prefix (so +"gpt-4o-mini"+ covers
+        # +"gpt-4o-mini-2024-07-18"+); Regexp patterns match as written. Later
+        # registrations win over earlier ones.
+        #
+        # @param pattern [String, Regexp] matched against the model name
+        # @param input [Float] USD per 1M input tokens
+        # @param output [Float] USD per 1M output tokens
+        # @return [Rate]
+        def register(pattern, input:, output:)
+          Rate.new(pattern: pattern, input: input.to_f, output: output.to_f).tap do |rate|
+            rates.unshift(rate)
+          end
+        end
+
+        # Clears the registry. Mostly useful in tests.
+        #
+        # @return [void]
+        def reset!
+          @rates = []
+        end
+
+        # @param model [String, nil]
+        # @return [Hash, nil] +{ input:, output: }+ in USD per 1M tokens
+        def rates_for(model)
+          return nil if model.blank?
+
+          rate = rates.find { |candidate| candidate.matches?(model) }
+          { input: rate.input, output: rate.output } if rate
+        end
+
+        # Computes the dollar cost of a single generation.
+        #
+        # @param usage [ActiveAgent::Providers::Common::Usage, nil]
+        # @param model [String, nil] used to look up registered rates
+        # @param rates [Hash, nil] inline +{ input:, output: }+ overriding the registry
+        # @return [Float, nil] nil when no rates are known for the model
+        def cost_for(usage:, model: nil, rates: nil)
+          return nil if usage.nil?
+
+          resolved = normalize(rates) || rates_for(model)
+          return nil if resolved.nil?
+
+          input  = (usage.input_tokens  || 0) * resolved[:input]
+          output = (usage.output_tokens || 0) * resolved[:output]
+
+          (input + output) / 1_000_000.0
+        end
+
+        private
+
+        # @param rates [Hash, nil]
+        # @return [Hash, nil]
+        def normalize(rates)
+          return nil if rates.blank?
+
+          rates = rates.symbolize_keys
+          return nil unless rates[:input] || rates[:output]
+
+          { input: rates[:input].to_f, output: rates[:output].to_f }
+        end
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/runner.rb
+++ b/lib/active_agent/delegation/runner.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+module ActiveAgent
+  module Delegation
+    # Executes one delegated call: budget check, sub-agent generation, result
+    # validation, accounting.
+    #
+    # The runner is what makes a sub-agent a *tool* rather than a method call.
+    # It answers to the calling model in the model's own terms — a refused call
+    # comes back as a structured result the model can reason about, not as an
+    # exception that ends the conversation.
+    #
+    # @api private
+    class Runner
+      # @return [Definition]
+      attr_reader :definition
+      # @return [ActiveAgent::Base] the delegating agent instance
+      attr_reader :owner
+
+      # @param definition [Definition]
+      # @param owner [ActiveAgent::Base]
+      def initialize(definition, owner:)
+        @definition = definition
+        @owner      = owner
+      end
+
+      # Runs the delegated call.
+      #
+      # @param arguments [Hash] arguments supplied by the calling model
+      # @return [Object] the sub-agent's result, or a structured error the
+      #   calling model can act on
+      # @raise [BudgetExceededError] when the budget policy is +:raise+
+      # @raise [InvalidResultError] when the returns policy is +:raise+
+      def call(**arguments)
+        if (violation = budget_violation)
+          return refuse(violation)
+        end
+
+        arguments = coerce_arguments(arguments)
+
+        instrument(arguments) do |payload|
+          started  = clock
+          response = nil
+
+          begin
+            response = with_timeout { generate(arguments) }
+          rescue Timeout::Error
+            duration = clock - started
+            record(duration: duration)
+            payload[:status]      = :timed_out
+            payload[:duration_ms] = (duration * 1_000).round
+
+            next timed_out(duration)
+          end
+
+          duration = clock - started
+          usage    = response.usage
+          model    = response.model.presence || generation_model(response)
+          cost     = Pricing.cost_for(usage: usage, model: model, rates: budget.rates)
+
+          record(tokens: usage&.total_tokens, cost: cost, duration: duration)
+
+          payload[:status]      = :ok
+          payload[:model]       = model
+          payload[:duration_ms] = (duration * 1_000).round
+          payload[:usage]       = usage
+          payload[:cost]        = cost
+          payload[:ledger]      = ledgers.last.to_h
+
+          result(response, payload)
+        end
+      end
+
+      private
+
+      # @return [Budget]
+      def budget = definition.budget
+
+      # Agent-wide ledger first, then this delegation's own — a call has to
+      # clear both.
+      #
+      # @return [Array<Ledger>]
+      def ledgers
+        @ledgers ||= [ owner.delegation_ledger, owner.delegation_ledger_for(definition.tool_name) ]
+      end
+
+      # @return [Budget::Violation, nil]
+      def budget_violation
+        owner.class.delegation_budget.violation_for(ledgers.first) || budget.violation_for(ledgers.last)
+      end
+
+      # @param tokens [Integer, nil]
+      # @param cost [Float, nil]
+      # @param duration [Float]
+      # @return [void]
+      def record(tokens: 0, cost: nil, duration: 0.0)
+        ledgers.each { |ledger| ledger.record(tokens: tokens, cost: cost, duration: duration) }
+      end
+
+      # Drops arguments the contract never declared, so a model that
+      # hallucinates an extra key gets a working call instead of an
+      # +ArgumentError+ from the sub-agent's method signature.
+      #
+      # @param arguments [Hash]
+      # @return [Hash]
+      def coerce_arguments(arguments)
+        arguments = arguments.symbolize_keys
+        return arguments if definition.schema.empty?
+
+        arguments.slice(*definition.schema.keys)
+      end
+
+      # @param arguments [Hash]
+      # @return [ActiveAgent::Providers::Common::PromptResponse]
+      def generate(arguments)
+        agent = definition.resolved_agent_class.new
+        agent.params = resolved_params(arguments)
+        agent.process(definition.action, **arguments)
+
+        definition.backend.apply(agent)
+        apply_returns_format(agent)
+        inherit_trace_id(agent)
+
+        agent.process_prompt
+      end
+
+      # A delegated generation is part of its parent's work, so it carries the
+      # parent's trace id — otherwise the sub-agent's tokens and latency land
+      # in a separate trace and the budget you set has nothing to show for it.
+      #
+      # @param agent [ActiveAgent::Base]
+      # @return [void]
+      def inherit_trace_id(agent)
+        trace_id = owner.prompt_options[:trace_id]
+        agent.prompt_options[:trace_id] ||= trace_id if trace_id
+      end
+
+      # A declared +returns+ schema *is* the response format for the delegated
+      # call; the sub-agent does not have to restate it.
+      #
+      # @param agent [ActiveAgent::Base]
+      # @return [void]
+      def apply_returns_format(agent)
+        return unless definition.structured?
+
+        agent.prompt_options[:response_format] = {
+          type: :json_schema,
+          json_schema: definition.returns.to_response_format(name: "#{definition.tool_name}_result")
+        }
+      end
+
+      # @param arguments [Hash]
+      # @return [Hash]
+      def resolved_params(arguments)
+        case (params = definition.params)
+        when nil    then {}
+        when Hash   then params
+        when Symbol then owner.send(params)
+        when Proc   then params.arity == 1 ? owner.instance_exec(arguments, &params) : owner.instance_exec(&params)
+        else
+          raise ArgumentError, "Delegation params must be a Hash, Symbol or Proc, got #{params.inspect}"
+        end.to_h.symbolize_keys
+      end
+
+      # @yield the delegated generation
+      # @return [Object]
+      def with_timeout
+        return yield unless budget.timeout
+
+        Timeout.timeout(budget.timeout) { yield }
+      end
+
+      # @param response [ActiveAgent::Providers::Common::PromptResponse]
+      # @param payload [Hash] instrumentation payload
+      # @return [Object]
+      def result(response, payload)
+        message = response.message
+        return nil if message.nil?
+
+        return text_of(message) unless definition.structured?
+
+        parsed  = message.respond_to?(:parsed_json) ? message.parsed_json : nil
+        missing = definition.returns.missing_keys(parsed)
+        return parsed if missing.empty?
+
+        payload[:status]  = :invalid_result
+        payload[:missing] = missing
+
+        invalid(missing, text_of(message))
+      end
+
+      # @param message [Object]
+      # @return [String]
+      def text_of(message)
+        message.respond_to?(:text) ? message.text : message.content.to_s
+      end
+
+      # @param response [ActiveAgent::Providers::Common::PromptResponse]
+      # @return [String, nil]
+      def generation_model(response)
+        response.context.is_a?(Hash) ? response.context[:model] : nil
+      end
+
+      # @param violation [Budget::Violation]
+      # @return [Hash]
+      def refuse(violation)
+        ActiveSupport::Notifications.instrument("delegation_refused.active_agent", instrument_payload.merge(
+          status: :budget_exceeded, limit: violation.limit, allowed: violation.allowed, used: violation.used
+        ))
+
+        if budget.policy == :raise
+          raise BudgetExceededError.new(violation, definition: definition)
+        end
+
+        { error: "budget_exceeded", limit: violation.limit.to_s, allowed: violation.allowed, used: violation.used, message: violation.message }
+      end
+
+      # @param duration [Float]
+      # @return [Hash]
+      def timed_out(duration)
+        if budget.policy == :raise
+          raise TimeoutError, "#{definition.agent_class}##{definition.action} exceeded its #{budget.timeout}s delegation timeout"
+        end
+
+        {
+          error: "timeout",
+          limit: "timeout",
+          allowed: budget.timeout,
+          used: duration.round(3),
+          message: "The #{definition.tool_name} delegation timed out after #{budget.timeout}s. " \
+                   "Answer with the information you already have, or call it with a smaller request."
+        }
+      end
+
+      # @param missing [Array<Symbol>]
+      # @param content [String]
+      # @return [Hash]
+      def invalid(missing, content)
+        if definition.on_invalid == :raise
+          raise InvalidResultError, "#{definition.agent_class}##{definition.action} returned a result missing " \
+            "required #{"key".pluralize(missing.size)}: #{missing.join(", ")}"
+        end
+
+        {
+          error: "invalid_result",
+          missing: missing.map(&:to_s),
+          message: "The #{definition.tool_name} delegation returned a result missing required " \
+                   "#{"key".pluralize(missing.size)}: #{missing.join(", ")}.",
+          content: content
+        }
+      end
+
+      # @param arguments [Hash]
+      # @yield [Hash] instrumentation payload
+      def instrument(arguments, &block)
+        ActiveSupport::Notifications.instrument(
+          "delegate.active_agent", instrument_payload.merge(arguments: arguments), &block
+        )
+      end
+
+      # @return [Hash]
+      def instrument_payload
+        {
+          agent: owner.class.name,
+          delegate: definition.agent_class.name,
+          action: definition.action,
+          tool: definition.tool_name.to_s,
+          provider: definition.backend.provider,
+          budget: budget.to_h.except(:rates)
+        }.compact
+      end
+
+      # Monotonic so a clock adjustment mid-generation can't corrupt a latency budget.
+      #
+      # @return [Float]
+      def clock
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/lib/active_agent/delegation/schema.rb
+++ b/lib/active_agent/delegation/schema.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+module ActiveAgent
+  module Delegation
+    # Declarative JSON Schema for a delegated agent's inputs and outputs.
+    #
+    # A delegation is only as good as its contract: the calling model needs to
+    # know exactly what a sub-agent accepts, and the calling *agent* needs to
+    # know what shape comes back. Schema builds both from a small DSL, from a
+    # plain JSON Schema hash, or from any class that responds to
+    # +to_json_schema+ (see {ActiveAgent::SchemaGenerator}).
+    #
+    # @example DSL
+    #   Schema.build do
+    #     string  :text, required: true, description: "Document to summarize"
+    #     integer :max_points, description: "How many bullets to return"
+    #     array   :tags, of: :string, description: "Topic tags"
+    #   end
+    #
+    # @example Plain JSON Schema
+    #   Schema.build(type: "object", properties: { text: { type: "string" } }, required: [ "text" ])
+    #
+    # @example ActiveModel / ActiveRecord
+    #   Schema.build(ContactForm) # ContactForm includes ActiveAgent::SchemaGenerator
+    class Schema
+      # Scalar types that get a one-line DSL helper.
+      SCALAR_TYPES = %i[string integer number boolean].freeze
+
+      class << self
+        # Coerces any supported schema source into a Schema.
+        #
+        # @param source [Schema, Hash, Class, nil] existing schema, raw JSON Schema,
+        #   or a class responding to +to_json_schema+
+        # @yield DSL block (evaluated against a new Schema, or yielded when arity is 1)
+        # @return [Schema]
+        # @raise [ArgumentError] when the source cannot be interpreted
+        def build(source = nil, &block)
+          schema =
+            case source
+            when Schema then source
+            when Hash   then from_hash(source)
+            when nil    then new
+            else
+              if source.respond_to?(:to_json_schema)
+                from_hash(source.to_json_schema)
+              else
+                raise ArgumentError, "Cannot build a delegation schema from #{source.inspect}. " \
+                  "Pass a Hash, a class responding to #to_json_schema, or use the block DSL."
+              end
+            end
+
+          if block
+            block.arity == 1 ? block.call(schema) : schema.instance_eval(&block)
+          end
+
+          schema
+        end
+
+        # @param hash [Hash] JSON Schema object
+        # @return [Schema]
+        def from_hash(hash)
+          hash = hash.deep_symbolize_keys
+
+          new.tap do |schema|
+            (hash[:properties] || {}).each { |name, definition| schema.property(name, definition) }
+            schema.required(*Array(hash[:required]))
+            schema.additional_properties(hash.fetch(:additionalProperties, hash.fetch(:additional_properties, false)))
+          end
+        end
+      end
+
+      def initialize
+        @properties           = {}
+        @required             = []
+        @additional_properties = false
+      end
+
+      # @return [Boolean] true when nothing has been declared
+      def empty?
+        @properties.empty?
+      end
+
+      # Declares a property from an already-built JSON Schema fragment.
+      #
+      # @param name [Symbol, String]
+      # @param definition [Hash] JSON Schema fragment (e.g. +{ type: "string" }+)
+      # @return [void]
+      def property(name, definition)
+        @properties[name.to_sym] = definition.deep_symbolize_keys
+      end
+
+      # Declares a property.
+      #
+      # @param name [Symbol, String]
+      # @param type [Symbol, String] JSON Schema type
+      # @param required [Boolean] whether the calling model must supply it
+      # @param description [String, nil] shown to the calling model — write it for a reader who
+      #   has never seen your code
+      # @param options [Hash] any other JSON Schema keyword (+enum+, +format+, +minimum+, ...)
+      # @yield nested DSL for object properties
+      # @return [void]
+      def param(name, type = :string, required: false, description: nil, **options, &block)
+        definition = { type: type.to_s, description: description }.compact.merge(options)
+
+        if block
+          nested = self.class.build(&block)
+          definition = definition.merge(nested.to_json_schema.except(:type))
+          definition[:type] = "object"
+        end
+
+        property(name, definition)
+        self.required(name) if required
+      end
+
+      SCALAR_TYPES.each do |type|
+        define_method(type) do |name, **options|
+          param(name, type, **options)
+        end
+      end
+
+      # Declares an object property.
+      #
+      # @param name [Symbol, String]
+      # @yield nested DSL
+      def object(name, **options, &block)
+        param(name, :object, **options, &block)
+      end
+
+      # Declares an array property.
+      #
+      # @param name [Symbol, String]
+      # @param of [Symbol, String, Hash, nil] item type, or a JSON Schema fragment for items
+      # @yield nested DSL describing an object item type
+      def array(name, of: nil, **options, &block)
+        items =
+          if block
+            self.class.build(&block).to_json_schema
+          elsif of.is_a?(Hash)
+            of.deep_symbolize_keys
+          elsif of
+            { type: of.to_s }
+          end
+
+        param(name, :array, **options.merge({ items: items }.compact))
+      end
+
+      # Marks properties as required.
+      #
+      # @param names [Array<Symbol, String>]
+      # @return [Array<Symbol>]
+      def required(*names)
+        names.flatten.each { |name| @required |= [ name.to_sym ] }
+        @required
+      end
+
+      # @param value [Boolean]
+      def additional_properties(value = true)
+        @additional_properties = value
+      end
+
+      # @return [Array<Symbol>] declared property names
+      def keys
+        @properties.keys
+      end
+
+      # @return [Array<Symbol>] required property names
+      def required_keys
+        @required.dup
+      end
+
+      # @return [Hash] JSON Schema object
+      #
+      # @note Deep-duplicated: providers normalize tool definitions in place,
+      #   and a schema is shared by every generation that exposes it.
+      def to_json_schema
+        {
+          type: "object",
+          properties: @properties.deep_dup,
+          required: @required.map(&:to_s),
+          additionalProperties: @additional_properties
+        }
+      end
+      alias_method :to_h, :to_json_schema
+
+      # JSON Schema for a +response_format+ payload.
+      #
+      # ActiveAgent camelizes response-format schema *keys* on the way to the
+      # provider, but the +required+ array holds string *values* — so they are
+      # camelized here to keep the emitted schema internally consistent.
+      # {Assistant#parsed_json} underscores the keys again on the way back, so
+      # agent code only ever sees snake_case.
+      #
+      # @param name [String] schema name reported to the provider
+      # @param strict [Boolean]
+      # @return [Hash]
+      def to_response_format(name:, strict: true)
+        schema = to_json_schema
+        schema[:required] = schema[:required].map { |key| key.camelize(:lower) }
+
+        { name: name, schema: schema, strict: strict }
+      end
+
+      # Validates a parsed payload against the declared required properties.
+      #
+      # This is a deliberately shallow check: it catches the failure that
+      # actually happens in practice (a model omitting a required key) without
+      # pulling a full JSON Schema validator into the gem's dependencies.
+      #
+      # @param payload [Hash, nil]
+      # @return [Array<Symbol>] missing required keys
+      def missing_keys(payload)
+        return required_keys if payload.nil?
+        return [] unless payload.is_a?(Hash)
+
+        keys = payload.keys.map { |key| key.to_s.underscore.to_sym }
+        required_keys.reject { |key| keys.include?(key) }
+      end
+    end
+  end
+end

--- a/test/docs/actions/delegation_examples_test.rb
+++ b/test/docs/actions/delegation_examples_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Docs
+  module Actions
+    # Worked example for the Delegation documentation.
+    #
+    # A support desk that triages tickets: a cheap classifier gives the ticket
+    # a category, a knowledge-base agent finds the relevant article, and a
+    # frontier model writes the reply. Each is its own agent with its own
+    # instructions and its own model — the triage agent just calls them.
+    class DelegationExamplesTest < ActiveSupport::TestCase
+      # region classifier_agent
+      class TicketClassifierAgent < ApplicationAgent
+        generate_with :openai, model: "gpt-4o-mini"
+
+        delegation :classify, description: "Classify a support ticket by topic and urgency" do
+          string :body, required: true, description: "The customer's message, verbatim"
+
+          returns do
+            string :category, required: true, enum: %w[billing bug account other],
+                              description: "What the ticket is about"
+            string :urgency, required: true, enum: %w[low normal high],
+                             description: "How quickly it needs a human"
+          end
+        end
+
+        def classify(body:)
+          prompt(message: body)
+        end
+      end
+      # endregion classifier_agent
+
+      # region knowledge_agent
+      class KnowledgeBaseAgent < ApplicationAgent
+        generate_with :openai, model: "gpt-4o-mini"
+
+        delegation :lookup, description: "Find the help-centre article that answers a question" do
+          string  :question, required: true, description: "The customer's question in plain language"
+          integer :limit, description: "How many articles to consider (default 5)"
+        end
+
+        def lookup(question:, limit: 5)
+          prompt(message: "Answer from the help centre, citing up to #{limit} article titles: #{question}")
+        end
+      end
+      # endregion knowledge_agent
+
+      # region triage_agent
+      class TriageAgent < ApplicationAgent
+        generate_with :openai, model: "gpt-4o"
+
+        # Ceiling for every delegation this agent makes in one generation.
+        delegation_budget max_calls: 6, max_duration: 45
+
+        delegate_to TicketClassifierAgent, budget: { max_calls: 1, timeout: 10 }
+        delegate_to KnowledgeBaseAgent, as: :search_help_centre,
+                    budget: { max_calls: 3, max_tokens: 20_000 }
+
+        def triage(ticket:)
+          prompt(message: "Triage this ticket. Classify it first, then find the article that answers it.\n\n#{ticket}")
+        end
+      end
+      # endregion triage_agent
+
+      test "the sub-agents' declared schemas are what the triage model sees" do
+        tools = TriageAgent.delegated_tools
+
+        doc_example_output(tools)
+
+        assert_equal %w[classify search_help_centre], tools.map { |tool| tool[:name] }
+        assert_equal "Classify a support ticket by topic and urgency", tools.first[:description]
+        assert_equal [ "body" ], tools.first[:parameters][:required]
+        assert_equal %w[question limit], tools.last[:parameters][:properties].keys.map(&:to_s)
+      end
+
+      test "budgets layer: the agent-wide ceiling and the per-delegation limit" do
+        budgets = {
+          agent: TriageAgent.delegation_budget.to_h,
+          classify: TriageAgent.delegations[:classify].budget.to_h,
+          search_help_centre: TriageAgent.delegations[:search_help_centre].budget.to_h
+        }
+
+        doc_example_output(budgets)
+
+        assert_equal({ max_calls: 6, max_duration: 45 }, budgets[:agent])
+        assert_equal({ max_calls: 1, timeout: 10 }, budgets[:classify])
+        assert_equal({ max_calls: 3, max_tokens: 20_000 }, budgets[:search_help_centre])
+      end
+
+      test "swapping a backend moves a sub-agent to another provider without editing it" do
+        # region backend_swap
+        class LocalTriageAgent < TriageAgent
+          # Same classifier, same contract, different silicon.
+          delegate_to TicketClassifierAgent, backend: { provider: :ollama, model: "gpt-oss:20b" }
+        end
+        # endregion backend_swap
+
+        swapped = LocalTriageAgent.delegations[:classify].resolved_agent_class
+
+        assert_equal "Ollama", swapped.prompt_options[:service]
+        assert_equal "gpt-oss:20b", swapped.prompt_options[:model]
+        assert_equal "OpenAI", TicketClassifierAgent.prompt_options[:service],
+          "the classifier itself is untouched"
+      end
+
+      test "a delegation is an ordinary method, so tests can call it without a model" do
+        # region testing_backend
+        class TestTriageAgent < TriageAgent
+          # Point the sub-agent at the mock provider; the contract is unchanged.
+          delegate_to KnowledgeBaseAgent, as: :search_help_centre, backend: :mock
+        end
+        # endregion testing_backend
+
+        # region testing_call
+        result = TestTriageAgent.new.search_help_centre(question: "How do I reset my password?")
+        # endregion testing_call
+
+        doc_example_output(result)
+
+        assert result.present?
+        assert_kind_of String, result
+      end
+
+      test "an exhausted budget answers the model instead of raising at it" do
+        capped = Class.new(TriageAgent) do
+          delegate_to KnowledgeBaseAgent, as: :search_help_centre, backend: :mock,
+                      budget: { max_calls: 1 }
+        end
+        agent = capped.new
+
+        agent.search_help_centre(question: "How do I reset my password?")
+
+        # region budget_exhausted
+        refused = agent.search_help_centre(question: "And how do I change my email?")
+        # endregion budget_exhausted
+
+        doc_example_output(refused)
+
+        assert_equal "budget_exceeded", refused[:error]
+        assert_equal "max_calls", refused[:limit]
+        assert_equal 1, agent.delegation_ledger.calls
+      end
+    end
+  end
+end

--- a/test/features/delegation_test.rb
+++ b/test/features/delegation_test.rb
@@ -1,0 +1,783 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../lib/active_agent/providers/mock_provider"
+
+# Agent-as-tool delegation: a sub-agent declares a contract, a parent exposes
+# it to its model as a tool, and every call runs under a budget on a
+# swappable backend.
+class DelegationTest < ActiveSupport::TestCase
+  ##### Test doubles ########################################################
+
+  # A fake model that emits a scripted batch of tool calls on its first
+  # response, then answers normally. This is the real provider tool loop —
+  # BaseProvider#process_prompt_finished routing through +tools_function+ —
+  # so delegated calls are exercised end to end without a network round trip.
+  class ScriptedProvider < ActiveAgent::Providers::MockProvider
+    # Type resolution derives from the class name; keep the Mock identity.
+    def self.name = "ActiveAgent::Providers::MockProvider"
+
+    class << self
+      # @return [Array<Array(String, Hash)>] tool calls the fake model emits
+      attr_accessor :tool_calls
+      # @return [Array] results the tools returned, in call order
+      attr_accessor :results
+
+      def script(*calls)
+        self.tool_calls = calls
+        self.results    = []
+      end
+    end
+
+    def process_prompt_finished_extract_function_calls
+      return nil if @emitted
+
+      @emitted = true
+      Array(self.class.tool_calls).map { |name, arguments| { name: name.to_s, input: arguments } }
+    end
+
+    def process_function_calls(function_calls)
+      function_calls.each do |function_call|
+        result = tools_function.call(function_call[:name], **function_call[:input])
+        self.class.results << result
+
+        message_stack.push({ role: "user", content: result.to_json })
+      end
+    end
+  end
+
+  # A fake model that answers with a fixed JSON payload, so structured
+  # +returns+ contracts can be exercised.
+  class JsonProvider < ActiveAgent::Providers::MockProvider
+    def self.name = "ActiveAgent::Providers::MockProvider"
+
+    class << self
+      # @return [Hash] payload the fake model answers with
+      attr_accessor :payload
+      # @return [Array<Hash>] response_format each request carried
+      attr_accessor :response_formats
+      # @return [Array<Hash>] full parameters each request carried
+      attr_accessor :requests
+    end
+
+    def api_prompt_execute(parameters)
+      self.class.response_formats << parameters[:response_format]
+      self.class.requests << parameters
+
+      super.merge("content" => [ { "type" => "text", "text" => self.class.payload.to_json } ])
+    end
+  end
+
+  # A fake model that never answers in time.
+  class SlowProvider < ActiveAgent::Providers::MockProvider
+    def self.name = "ActiveAgent::Providers::MockProvider"
+
+    def api_prompt_execute(parameters)
+      sleep 5
+      super
+    end
+  end
+
+  ##### Agents ##############################################################
+
+  class SummarizerAgent < ApplicationAgent
+    generate_with :mock, model: "mock-model"
+
+    delegation :summarize, description: "Condense a document into key points" do
+      string  :text, required: true, description: "Full document text"
+      integer :limit, description: "Maximum number of key points to return"
+    end
+
+    delegation :outline, description: "Produce a section outline for a document" do
+      string :text, required: true, description: "Full document text"
+    end
+
+    def summarize(text:, limit: 5)
+      prompt(message: "Summarize in #{limit} points: #{text}")
+    end
+
+    def outline(text:)
+      prompt(message: "Outline: #{text}")
+    end
+  end
+
+  class ExtractorAgent < ApplicationAgent
+    generate_with :mock, model: "mock-model"
+
+    delegation :extract, description: "Extract the contact details from a document" do
+      string :text, required: true, description: "Document text"
+
+      returns do
+        string :name, required: true, description: "Full name"
+        string :email, required: true, description: "Email address"
+      end
+    end
+
+    def extract(text:)
+      prompt(message: text)
+    end
+  end
+
+  class UndeclaredAgent < ApplicationAgent
+    generate_with :mock, model: "mock-model"
+
+    def classify(body:)
+      prompt(message: body)
+    end
+  end
+
+  class ResearchAgent < ApplicationAgent
+    generate_with :mock, model: "mock-model"
+
+    delegate_to SummarizerAgent
+
+    def research
+      prompt(message: "Research the topic")
+    end
+  end
+
+  ##### Contracts and schemas ###############################################
+
+  test "a declared contract becomes a tool the calling model can see" do
+    tool = ResearchAgent.delegated_tools.find { |candidate| candidate[:name] == "summarize" }
+
+    assert_equal "Condense a document into key points", tool[:description]
+    assert_equal "object", tool[:parameters][:type]
+    assert_equal({ type: "string", description: "Full document text" }, tool[:parameters][:properties][:text])
+    assert_equal "integer", tool[:parameters][:properties][:limit][:type]
+    assert_equal [ "text" ], tool[:parameters][:required]
+    assert_equal false, tool[:parameters][:additionalProperties]
+  end
+
+  test "the schema DSL covers scalars, arrays and nested objects" do
+    schema = ActiveAgent::Delegation::Schema.build do
+      string  :query, required: true, description: "Search text"
+      number  :threshold
+      boolean :fuzzy
+      array   :tags, of: :string, description: "Topic tags"
+      array   :people do
+        string :name, required: true
+      end
+      object :filters do
+        string :status, description: "Ticket status"
+      end
+    end
+
+    json = schema.to_json_schema
+
+    assert_equal "number",  json[:properties][:threshold][:type]
+    assert_equal "boolean", json[:properties][:fuzzy][:type]
+    assert_equal({ type: "string" }, json[:properties][:tags][:items])
+    assert_equal "object", json[:properties][:people][:items][:type]
+    assert_equal [ "name" ], json[:properties][:people][:items][:required]
+    assert_equal "string", json[:properties][:filters][:properties][:status][:type]
+    assert_equal [ "query" ], json[:required]
+  end
+
+  test "a schema can be built from a plain JSON Schema hash" do
+    schema = ActiveAgent::Delegation::Schema.build(
+      type: "object",
+      properties: { locale: { type: "string" } },
+      required: [ "locale" ]
+    )
+
+    assert_equal [ :locale ], schema.keys
+    assert_equal [ :locale ], schema.required_keys
+  end
+
+  test "a schema can be built from any class that generates one" do
+    model = Class.new do
+      def self.to_json_schema
+        { type: "object", properties: { subject: { type: "string" } }, required: [ "subject" ] }
+      end
+    end
+
+    assert_equal [ :subject ], ActiveAgent::Delegation::Schema.build(model).required_keys
+  end
+
+  test "a contract without a description is refused" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ApplicationAgent) { delegation :summarize, description: "" }
+    end
+
+    assert_match(/description/, error.message)
+  end
+
+  ##### delegate_to #########################################################
+
+  test "delegating exposes every contract the sub-agent declares" do
+    agent = Class.new(ApplicationAgent) { delegate_to SummarizerAgent }
+
+    assert_equal [ :summarize, :outline ], agent.delegations.keys
+  end
+
+  test "only: and except: narrow what is exposed" do
+    only   = Class.new(ApplicationAgent) { delegate_to SummarizerAgent, only: :summarize }
+    except = Class.new(ApplicationAgent) { delegate_to SummarizerAgent, except: :outline }
+
+    assert_equal [ :summarize ], only.delegations.keys
+    assert_equal [ :summarize ], except.delegations.keys
+  end
+
+  test "as: renames the tool the model sees" do
+    agent = Class.new(ApplicationAgent) { delegate_to SummarizerAgent, only: :summarize, as: :condense }
+
+    assert_equal [ :condense ], agent.delegations.keys
+    assert_equal :summarize, agent.delegations[:condense].action
+    assert_equal "condense", agent.delegated_tools.first[:name]
+  end
+
+  test "a contract can be declared at the call site for an agent you do not own" do
+    agent = Class.new(ApplicationAgent) do
+      delegate_to UndeclaredAgent, action: :classify, description: "Classify a support ticket" do
+        string :body, required: true, description: "Ticket body"
+      end
+    end
+
+    tool = agent.delegated_tools.first
+
+    assert_equal "classify", tool[:name]
+    assert_equal "Classify a support ticket", tool[:description]
+    assert_equal [ "body" ], tool[:parameters][:required]
+  end
+
+  test "delegating to an agent with no contracts explains how to declare one" do
+    error = assert_raises(ArgumentError) { Class.new(ApplicationAgent) { delegate_to UndeclaredAgent } }
+
+    assert_match(/does not declare any delegations/, error.message)
+    assert_match(/delegate_to .*action: :action_name/, error.message)
+  end
+
+  test "delegating to an action the sub-agent does not define is refused" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ApplicationAgent) { delegate_to UndeclaredAgent, action: :nope, description: "Nope" }
+    end
+
+    assert_match(/does not define #nope/, error.message)
+  end
+
+  test "delegating to something that is not an agent is refused" do
+    error = assert_raises(ArgumentError) { Class.new(ApplicationAgent) { delegate_to String } }
+
+    assert_match(/expects an ActiveAgent::Base subclass/, error.message)
+  end
+
+  test "a tool name that collides with an existing method is refused" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ApplicationAgent) do
+        def summarize(*) = nil
+        delegate_to SummarizerAgent, only: :summarize
+      end
+    end
+
+    assert_match(/already responds to #summarize/, error.message)
+    assert_match(/Rename it with `as:`/, error.message)
+  end
+
+  test "as: is refused when it would rename more than one delegation" do
+    error = assert_raises(ArgumentError) { Class.new(ApplicationAgent) { delegate_to SummarizerAgent, as: :thing } }
+
+    assert_match(/Narrow it with `only:`/, error.message)
+  end
+
+  test "only: with an undeclared action lists what is available" do
+    error = assert_raises(ArgumentError) { Class.new(ApplicationAgent) { delegate_to SummarizerAgent, only: :ghost } }
+
+    assert_match(/does not declare delegation ghost/, error.message)
+    assert_match(/It declares: summarize, outline/, error.message)
+  end
+
+  ##### Prompt wiring #######################################################
+
+  test "delegated tools reach the provider alongside the action's own tools" do
+    agent_class = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegate_to SummarizerAgent, only: :summarize
+
+      def research
+        prompt(message: "go", tools: [ { name: "search", description: "Search", parameters: { type: "object", properties: {} } } ])
+      end
+    end
+
+    parameters = prepared_parameters(agent_class, :research)
+
+    assert_equal %w[search summarize], parameters[:tools].map { |tool| tool[:name] }
+  end
+
+  test "an action can opt out of delegations entirely" do
+    agent_class = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegate_to SummarizerAgent
+
+      def research = prompt(message: "go", delegations: false)
+    end
+
+    assert_nil prepared_parameters(agent_class, :research)[:tools]
+  end
+
+  test "an action can scope itself to a subset of delegations" do
+    agent_class = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegate_to SummarizerAgent
+
+      def research = prompt(message: "go", delegations: [ :outline ])
+    end
+
+    assert_equal %w[outline], prepared_parameters(agent_class, :research)[:tools].map { |tool| tool[:name] }
+  end
+
+  test "scoping to an unknown delegation lists what the agent delegates to" do
+    agent_class = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegate_to SummarizerAgent
+
+      def research = prompt(message: "go", delegations: [ :ghost ])
+    end
+
+    error = assert_raises(ArgumentError) { prepared_parameters(agent_class, :research) }
+
+    assert_match(/Unknown delegation: ghost/, error.message)
+    assert_match(/summarize, outline/, error.message)
+  end
+
+  test "the delegations prompt option never reaches the provider" do
+    agent_class = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegate_to SummarizerAgent, only: :summarize
+
+      def research = prompt(message: "go", delegations: [ :summarize ])
+    end
+
+    assert_not prepared_parameters(agent_class, :research).key?(:delegations)
+  end
+
+  ##### End-to-end delegation ###############################################
+
+  test "the calling model's tool call runs the sub-agent and gets its answer back" do
+    parent = scripted_agent([ :summarize, { text: "A long document", limit: 3 } ], delegate: SummarizerAgent)
+
+    response = parent.research.generate_now
+
+    assert response.message.content.present?
+    assert_equal 1, ScriptedProvider.results.length
+    assert_kind_of String, ScriptedProvider.results.first
+    assert ScriptedProvider.results.first.present?
+  end
+
+  test "arguments the contract never declared are dropped rather than crashing the sub-agent" do
+    parent = scripted_agent([ :summarize, { text: "doc", limit: 2, hallucinated: "nonsense" } ], delegate: SummarizerAgent)
+
+    parent.research.generate_now
+
+    assert_equal 1, ScriptedProvider.results.length
+    assert_kind_of String, ScriptedProvider.results.first
+  end
+
+  test "each delegated call is recorded on the agent's ledger" do
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], [ :summarize, { text: "two" } ], delegate: SummarizerAgent
+    )
+
+    agent = parent.new
+    agent.process(:research)
+    agent.process_prompt
+
+    assert_equal 2, agent.delegation_ledger.calls
+    assert_equal 2, agent.delegation_ledger_for(:summarize).calls
+    assert_operator agent.delegation_ledger.tokens, :>, 0
+    assert_operator agent.delegation_ledger.duration, :>=, 0
+  end
+
+  test "delegated calls are instrumented" do
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe("delegate.active_agent") { |*, payload| events << payload }
+
+    parent = scripted_agent([ :summarize, { text: "doc" } ], delegate: SummarizerAgent)
+    parent.research.generate_now
+
+    assert_equal 1, events.length
+    assert_equal "summarize", events.first[:tool]
+    assert_equal :summarize, events.first[:action]
+    assert_equal :ok, events.first[:status]
+    assert_operator events.first[:duration_ms], :>=, 0
+    assert events.first[:usage].present?
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
+  test "a delegated generation runs under the parent's trace id" do
+    trace_ids = []
+    subscription = ActiveSupport::Notifications.subscribe("prompt.active_agent") do |*, payload|
+      trace_ids << payload[:trace_id]
+    end
+
+    parent = scripted_agent([ :summarize, { text: "doc" } ], delegate: SummarizerAgent)
+    parent.research.generate_now
+
+    assert_equal 1, trace_ids.compact.uniq.length, "parent and sub-agent share one trace"
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
+  ##### Budgets #############################################################
+
+  test "a call budget stops delegating and tells the model why" do
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], [ :summarize, { text: "two" } ], [ :summarize, { text: "three" } ],
+      delegate: SummarizerAgent, budget: { max_calls: 2 }
+    )
+
+    parent.research.generate_now
+
+    refused = ScriptedProvider.results.last
+
+    assert_equal "budget_exceeded", refused[:error]
+    assert_equal "max_calls", refused[:limit]
+    assert_equal 2, refused[:allowed]
+    assert_equal 2, refused[:used]
+    assert_match(/Do not retry this tool/, refused[:message])
+  end
+
+  test "an agent-wide budget covers every delegation together" do
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], [ :outline, { text: "two" } ], [ :summarize, { text: "three" } ],
+      delegate: SummarizerAgent
+    )
+    parent.delegation_budget max_calls: 2
+
+    parent.research.generate_now
+
+    assert_equal "budget_exceeded", ScriptedProvider.results.last[:error]
+    assert_equal 2, ScriptedProvider.results.count { |result| result.is_a?(String) }
+  end
+
+  test "a token budget stops delegating once the sub-agent has spent it" do
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], [ :summarize, { text: "two" } ],
+      delegate: SummarizerAgent, budget: { max_tokens: 1 }
+    )
+
+    parent.research.generate_now
+
+    assert_kind_of String, ScriptedProvider.results.first
+    assert_equal "max_tokens", ScriptedProvider.results.last[:limit]
+  end
+
+  test "a budget can be configured to raise instead of degrading" do
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], [ :summarize, { text: "two" } ],
+      delegate: SummarizerAgent, budget: { max_calls: 1, on_exceeded: :raise }
+    )
+
+    error = assert_raises(ActiveAgent::Delegation::BudgetExceededError) { parent.research.generate_now }
+
+    assert_equal :max_calls, error.violation.limit
+    assert_match(/exceeded its delegation budget/, error.message)
+  end
+
+  test "budgets are scoped to one generation" do
+    parent = scripted_agent([ :summarize, { text: "one" } ], delegate: SummarizerAgent, budget: { max_calls: 1 })
+
+    2.times do
+      ScriptedProvider.script([ :summarize, { text: "one" } ])
+      parent.research.generate_now
+
+      assert_kind_of String, ScriptedProvider.results.first, "each generation starts with a fresh budget"
+    end
+  end
+
+  test "a per-call timeout degrades into an answerable result" do
+    sub = Class.new(SummarizerAgent) { self._prompt_provider_klass = SlowProvider }
+    parent = scripted_agent([ :summarize, { text: "one" } ], delegate: sub, budget: { timeout: 0.1 })
+
+    parent.research.generate_now
+
+    timed_out = ScriptedProvider.results.first
+
+    assert_equal "timeout", timed_out[:error]
+    assert_equal 0.1, timed_out[:allowed]
+    assert_match(/timed out/, timed_out[:message])
+  end
+
+  test "a timed-out call still counts against the budget" do
+    sub = Class.new(SummarizerAgent) { self._prompt_provider_klass = SlowProvider }
+    parent = scripted_agent([ :summarize, { text: "one" } ], delegate: sub, budget: { timeout: 0.1 })
+
+    agent = parent.new
+    agent.process(:research)
+    agent.process_prompt
+
+    assert_equal 1, agent.delegation_ledger.calls
+    assert_operator agent.delegation_ledger.duration, :>=, 0.1
+  end
+
+  test "a budget rejects unknown limits and policies" do
+    assert_match(/Unknown delegation budget keys: max_spend/,
+      assert_raises(ArgumentError) { ActiveAgent::Delegation::Budget.build(max_spend: 1) }.message)
+
+    assert_match(/Unknown delegation budget policy/,
+      assert_raises(ArgumentError) { ActiveAgent::Delegation::Budget.build(on_exceeded: :explode) }.message)
+  end
+
+  test "a call-site budget layers over the contract's own default" do
+    sub = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegation :work, description: "Do work", budget: { max_calls: 9, timeout: 30 }
+      def work = prompt(message: "work")
+    end
+
+    parent = Class.new(ApplicationAgent) { delegate_to sub, budget: { max_calls: 2 } }
+    budget = parent.delegations[:work].budget
+
+    assert_equal 2, budget.max_calls, "the call site knows what the work is worth"
+    assert_equal 30, budget.timeout, "the contract's default survives where the call site is silent"
+  end
+
+  ##### Cost ################################################################
+
+  test "registered rates turn token usage into a cost budget" do
+    ActiveAgent::Delegation::Pricing.register("mock-model", input: 1_000_000.0, output: 1_000_000.0)
+
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], [ :summarize, { text: "two" } ],
+      delegate: SummarizerAgent, budget: { max_cost: 0.5 }
+    )
+
+    parent.research.generate_now
+
+    assert_kind_of String, ScriptedProvider.results.first
+    assert_equal "max_cost", ScriptedProvider.results.last[:limit]
+  end
+
+  test "rates can be stated inline on a budget" do
+    usage = ActiveAgent::Providers::Common::Usage.new(input_tokens: 1_000_000, output_tokens: 500_000)
+    cost  = ActiveAgent::Delegation::Pricing.cost_for(usage: usage, model: "unpriced", rates: { input: 0.15, output: 0.60 })
+
+    assert_in_delta 0.45, cost, 0.0001
+  end
+
+  test "cost is nil when no rates are known, so an unpriced model never fakes a number" do
+    usage = ActiveAgent::Providers::Common::Usage.new(input_tokens: 100, output_tokens: 100)
+
+    assert_nil ActiveAgent::Delegation::Pricing.cost_for(usage: usage, model: "who-knows")
+  end
+
+  test "registered rates match by prefix and by pattern" do
+    ActiveAgent::Delegation::Pricing.register("gpt-4o-mini", input: 0.15, output: 0.60)
+    ActiveAgent::Delegation::Pricing.register(/\Aclaude-haiku/, input: 1.0, output: 5.0)
+
+    assert_equal({ input: 0.15, output: 0.60 }, ActiveAgent::Delegation::Pricing.rates_for("gpt-4o-mini-2024-07-18"))
+    assert_equal({ input: 1.0, output: 5.0 }, ActiveAgent::Delegation::Pricing.rates_for("claude-haiku-4-5"))
+    assert_nil ActiveAgent::Delegation::Pricing.rates_for("llama3.1")
+  end
+
+  ##### Backends ############################################################
+
+  test "a backend can swap the model without touching the sub-agent" do
+    parent = scripted_agent(
+      [ :summarize, { text: "one" } ], delegate: SummarizerAgent, backend: { model: "swapped-model", temperature: 0 }
+    )
+
+    parent.research.generate_now
+
+    assert_equal "swapped-model", last_delegated_model
+    assert_equal "mock-model", SummarizerAgent.prompt_options[:model], "the sub-agent's own configuration is untouched"
+  end
+
+  test "a backend can swap the provider, and the sub-agent's views still resolve" do
+    parent = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegate_to SummarizerAgent, only: :summarize, backend: :openai
+    end
+
+    resolved = parent.delegations[:summarize].resolved_agent_class
+
+    assert_not_equal SummarizerAgent, resolved
+    assert_operator resolved, :<, SummarizerAgent
+    assert_equal "OpenAI", resolved.prompt_options[:service]
+    assert_equal SummarizerAgent.name, resolved.name, "view lookup follows the class name"
+    assert_equal SummarizerAgent.name.underscore, resolved.new.agent_name
+    assert_equal "Mock", SummarizerAgent.prompt_options[:service], "the sub-agent's own provider is untouched"
+  end
+
+  test "the swapped class is built once and reused" do
+    definition = Class.new(ApplicationAgent) do
+      delegate_to SummarizerAgent, only: :summarize, backend: { provider: :openai }
+    end.delegations[:summarize]
+
+    assert_same definition.resolved_agent_class, definition.resolved_agent_class
+  end
+
+  test "an agent with no backend override runs on its own configuration" do
+    definition = ResearchAgent.delegations[:summarize]
+
+    assert_same SummarizerAgent, definition.resolved_agent_class
+    assert_not definition.backend.overrides?
+  end
+
+  ##### Structured returns ##################################################
+
+  test "a declared returns schema becomes the sub-agent's response format" do
+    JsonProvider.payload           = { name: "Ada Lovelace", email: "ada@example.com" }
+    JsonProvider.response_formats  = []
+    JsonProvider.requests          = []
+
+    sub    = Class.new(ExtractorAgent) { self._prompt_provider_klass = JsonProvider }
+    parent = scripted_agent([ :extract, { text: "Ada Lovelace <ada@example.com>" } ], delegate: sub)
+
+    parent.research.generate_now
+
+    format = JsonProvider.response_formats.compact.first
+
+    assert_equal "json_schema", format[:type].to_s
+    assert_equal "extract_result", format[:json_schema][:name]
+    assert_equal %w[name email], format[:json_schema][:schema][:properties].keys.map(&:to_s)
+    assert_equal %w[name email], format[:json_schema][:schema][:required]
+  end
+
+  test "a structured sub-agent hands back parsed data, not a blob of text" do
+    JsonProvider.payload          = { name: "Ada Lovelace", email: "ada@example.com" }
+    JsonProvider.response_formats = []
+    JsonProvider.requests         = []
+
+    sub    = Class.new(ExtractorAgent) { self._prompt_provider_klass = JsonProvider }
+    parent = scripted_agent([ :extract, { text: "Ada Lovelace <ada@example.com>" } ], delegate: sub)
+
+    parent.research.generate_now
+
+    assert_equal({ name: "Ada Lovelace", email: "ada@example.com" }, ScriptedProvider.results.first)
+  end
+
+  test "output that breaks the contract comes back as something the model can act on" do
+    JsonProvider.payload          = { name: "Ada Lovelace" }
+    JsonProvider.response_formats = []
+    JsonProvider.requests         = []
+
+    sub    = Class.new(ExtractorAgent) { self._prompt_provider_klass = JsonProvider }
+    parent = scripted_agent([ :extract, { text: "Ada Lovelace" } ], delegate: sub)
+
+    parent.research.generate_now
+
+    invalid = ScriptedProvider.results.first
+
+    assert_equal "invalid_result", invalid[:error]
+    assert_equal [ "email" ], invalid[:missing]
+    assert_match(/missing required key: email/, invalid[:message])
+  end
+
+  test "contract violations can be configured to raise" do
+    strict = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+
+      delegation :extract, description: "Extract contact details", on_invalid: :raise do
+        string :text, required: true, description: "Document text"
+        returns { string :email, required: true, description: "Email address" }
+      end
+
+      def extract(text:) = prompt(message: text)
+    end
+
+    JsonProvider.payload          = { nope: true }
+    JsonProvider.response_formats = []
+    JsonProvider.requests         = []
+    strict._prompt_provider_klass = JsonProvider
+
+    parent = scripted_agent([ :extract, { text: "doc" } ], delegate: strict)
+
+    error = assert_raises(ActiveAgent::Delegation::InvalidResultError) { parent.research.generate_now }
+
+    assert_match(/missing required key: email/, error.message)
+  end
+
+  test "a returns schema keeps its required list consistent with the keys it emits" do
+    schema = ActiveAgent::Delegation::Schema.build do
+      string :max_points, required: true
+    end
+
+    format = schema.to_response_format(name: "result")
+
+    assert_equal [ "maxPoints" ], format[:required] || format[:schema][:required]
+    assert format[:strict]
+  end
+
+  ##### Params ##############################################################
+
+  test "params can be forwarded to the sub-agent" do
+    sub = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegation :echo, description: "Echo the tenant" do
+        string :text, required: true, description: "Text"
+      end
+
+      def echo(text:) = prompt(message: "#{params[:tenant]}: #{text}")
+    end
+
+    parent = scripted_agent([ :echo, { text: "hi" } ], delegate: sub, params: { tenant: "acme" })
+    parent.research.generate_now
+
+    assert_match(/acme/i, ScriptedProvider.results.first)
+  end
+
+  test "params can be computed from the delegating agent" do
+    sub = Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      delegation :echo, description: "Echo the tenant" do
+        string :text, required: true, description: "Text"
+      end
+
+      def echo(text:) = prompt(message: "#{params[:tenant]}: #{text}")
+    end
+
+    parent = scripted_agent([ :echo, { text: "hi" } ], delegate: sub, params: :tenant_params)
+    parent.class_eval { define_method(:tenant_params) { { tenant: "override" } } }
+    parent.research.generate_now
+
+    assert_match(/override/i, ScriptedProvider.results.first)
+  end
+
+  private
+
+  # Builds a delegating agent whose model emits the given tool calls.
+  #
+  # @param calls [Array<Array(Symbol, Hash)>]
+  # @return [Class]
+  def scripted_agent(*calls, delegate:, **delegation_options)
+    ScriptedProvider.script(*calls)
+
+    Class.new(ApplicationAgent) do
+      generate_with :mock, model: "mock-model"
+      self._prompt_provider_klass = ScriptedProvider
+
+      delegate_to delegate, **delegation_options
+
+      def research = prompt(message: "Research the topic")
+    end
+  end
+
+  # @return [Hash] the parameters an action would send to its provider
+  def prepared_parameters(agent_class, action)
+    agent = agent_class.new
+    agent.process(action)
+    agent.send(:prepare_prompt_parameters)
+  end
+
+  # @return [String, nil] the model the most recent delegated call ran on
+  def last_delegated_model
+    @last_delegated_model
+  end
+
+  def setup
+    ActiveAgent::Delegation::Pricing.reset!
+    ScriptedProvider.script
+    @delegate_events = []
+    @subscription = ActiveSupport::Notifications.subscribe("delegate.active_agent") do |*, payload|
+      @last_delegated_model = payload[:model]
+      @delegate_events << payload
+    end
+  end
+
+  def teardown
+    ActiveSupport::Notifications.unsubscribe(@subscription)
+    ActiveAgent::Delegation::Pricing.reset!
+  end
+end


### PR DESCRIPTION
Implements item 4 of `docs/framework/v2-extraction-roadmap.md`:

> **Agent-to-agent delegation.** `tools_function` only routes back to `self`. The platform built `call_agent` (sub-agent invocation with a `Thread.current` depth cap) as an app tool. v2: a first-class delegation primitive — invoke another agent class/instance as a tool, with depth limits and shared trace/context correlation.

It also covers the remainder of item 3 ("a token/cost budget alongside the turn cap"). The code this supersedes is `AgentExecutionService#call_agent` in the platform app — `MAX_CALL_DEPTH = 2`, guarded by a thread-local counter.

## What this is

A tool is a Ruby method the model can call. A delegation is another agent the model can call. The callee keeps its own instructions, templates, model and budget, so a specialist agent stays specialist and the generalist orchestrating it never inherits its prompt.

Three declarations, each where the knowledge lives:

**The contract lives on the sub-agent.**

```ruby
class SummarizerAgent < ApplicationAgent
  generate_with :openai, model: "gpt-4o-mini"

  delegation :summarize, description: "Condense a document into key points" do
    string  :text, required: true, description: "Full document text"
    integer :limit, description: "Maximum number of key points"

    returns do
      string :summary, required: true
      array  :points, of: :string, required: true
    end
  end

  def summarize(text:, limit: 5)
    prompt(message: "Summarize in #{limit} points: #{text}")
  end
end
```

Inputs come from a block DSL, a plain JSON Schema hash, or any class responding to `to_json_schema`. A declared `returns` becomes the sub-agent's `response_format`; its answer is parsed and checked against the required keys before the caller sees it, so callers receive data rather than text to re-parse.

**The budget lives at the call site**, because only the caller knows what the work is worth.

```ruby
class ResearchAgent < ApplicationAgent
  delegation_budget max_calls: 8, max_duration: 60

  delegate_to SummarizerAgent, budget: { max_calls: 3, timeout: 20 }
  delegate_to FactCheckAgent, as: :verify,
              backend: { provider: :anthropic, model: "claude-haiku-4-5" }
end
```

`max_calls`, `max_tokens`, `max_cost`, `max_duration` and a per-call `timeout`. Exhausting one returns a structured result the model can reason about rather than raising mid-conversation:

```ruby
{ error: "budget_exceeded", limit: "max_calls", allowed: 3, used: 3,
  message: "Delegation budget exhausted... answer with the information you already have." }
```

`on_exceeded: :raise` is available. Ledgers live on the agent instance, so a budget is scoped to one generation with nothing to reset.

**The backend lives at the call site too.** Provider swaps go through a cached subclass configured by `generate_with` rather than merging a hash over stale provider config, and the subclass reports its parent's name so template lookup still resolves to the original agent's views.

## Notes for review

- **`Delegation::Pricing` ships with an empty table on purpose.** Vendor pricing moves faster than gem releases and a stale table silently under-reports spend, so apps register their own rates or state them inline on a budget. The tradeoff: `max_cost` does nothing until someone registers rates. (solid_agent's `ModelPricing` already solves this better — if the two gems should share it, that is worth discussing here.)
- **One line outside the feature.** `prepare_prompt_parameters` now writes the trace id back into `prompt_options` (`||=` instead of `||`) so delegated sub-agents inherit it and a delegation tree reads as one trace. The telemetry instrumentation already did this write-back when enabled.
- Delegated tools merge into the action's own `tools:`; scope per action with `delegations: false` or `delegations: [:name]`.

## Verification

- 54 new tests covering the schema DSL, contract errors, tool wiring, the real provider tool loop end-to-end (scripted mock provider, no network), every budget limit, timeouts, backend swaps, structured returns and their failure path, ledgers, pricing, instrumentation and trace inheritance.
- Full suite: **1341 runs, 0 failures**. The 253 errors are pre-existing `Missing credentials` from integration tests needing API keys — confirmed identical on a stashed baseline before any of these changes.
- Rubocop clean across all 382 files.

## Open question

`activeagents/solid_agent#2` ports this same work into solid_agent. I believe that one should be closed in favour of this PR: the roadmap's three-layer split puts execution in activeagent and persistence in solid_agent, and delegation is execution. Flagging it so the decision is explicit rather than implied by whichever merges first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbmULyN7NyPwv62s7eWRmD)_