### PR TITLE
fix(actionagent): resolve every engine constant under a host's inflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-08-14
+
+### Fixed
+
+- **`actionagent`: every engine constant resolves under a host's
+  inflections.** 1.2.1 scoped its autoloader override to the basename `api`,
+  which covered the controllers under `app/controllers/action_agent/api` and
+  nothing else. Seven files camelize differently once a host registers an
+  acronym — `mcp_catalog.rb`, `mcp_recording_middleware.rb`,
+  `playwright_mcp_client.rb`, `api_key.rb`, and the `api_keys`, `mcp` and
+  `mcp_servers` controllers — and each raised `Zeitwerk::NameError` on first
+  reference. In a host declaring `inflect.acronym "MCP"` the **Tools view was
+  unreachable** (`uninitialized constant
+  ActionAgent::ToolDiscovery::McpCatalog`), as were the MCP endpoints and
+  anything touching an API key.
+
+  Every path under the engine now camelizes with Zeitwerk's default
+  inflector, ignoring the host's acronyms, scoped by path so the host's own
+  constants keep their spelling. The router half generalizes with it: an
+  all-caps run in a missing constant is retried in the relaxed spelling
+  (`API` → `Api`, `MCPServersController` → `McpServersController`) rather
+  than aliasing each pair by hand.
+
 ## [1.2.1] - 2026-08-14
 
 ### Fixed

--- a/actionagent/lib/action_agent/engine.rb
+++ b/actionagent/lib/action_agent/engine.rb
@@ -13,6 +13,13 @@ module ActionAgent
 
     engine_name "action_agent"
 
+    # Basenames this engine spells differently from Zeitwerk's default
+    # camelization, consulted by the inflections initializer below. Empty
+    # today: every file here is named for the constant default camelization
+    # produces. An engine file that wants a genuine acronym in its constant
+    # adds its basename here rather than relying on the host to register one.
+    INFLECTION_OVERRIDES = {}.freeze
+
     config.action_agent = ActiveSupport::OrderedOptions.new
 
     # The dashboard's JS and CSS ship prebuilt in the gem. Adding the
@@ -26,26 +33,34 @@ module ActionAgent
       app.config.filter_parameters += [ :credential, :api_key, :access_token ]
     end
 
-    # The controllers under app/controllers/action_agent/api are ActionAgent::Api,
-    # but an engine's files are autoloaded by the host's `rails.main` loader,
-    # under the host's inflections. A host that declares `inflect.acronym "API"`
-    # — common enough that Rails documents it — makes Zeitwerk expect
-    # ActionAgent::API::TracesController in a file that defines
-    # ActionAgent::Api::TracesController, and every request to the mount raises
-    # Zeitwerk::NameError.
+    # This engine's constants are spelled the way Zeitwerk's own inflector
+    # spells them — Api, McpCatalog, ApiKey — but an engine's files are
+    # autoloaded by the host's `rails.main` loader, under the *host's*
+    # inflections. A host that declares `inflect.acronym "API"` or "MCP" (both
+    # common, and documented by Rails) makes Zeitwerk expect
+    # ActionAgent::API::TracesController or ActionAgent::MCPCatalog from files
+    # that define ActionAgent::Api::TracesController and
+    # ActionAgent::McpCatalog. The constant never resolves and the request
+    # raises Zeitwerk::NameError.
     #
-    # Scoped to this engine's own path rather than set through `inflect`: the
-    # loader is shared, so a blanket rule would re-spell the host's own API
-    # constants. `camelize` receives the absolute path, which is the only hook
-    # that can tell this engine's api/ from the host's.
+    # Every path under this engine therefore camelizes with Zeitwerk's default
+    # rules, ignoring whatever acronyms the host has registered. Applied by
+    # path rather than through `inflect`: the loader is shared with the host,
+    # so a blanket rule would re-spell the host's own constants. `camelize`
+    # receives the absolute path, which is the only hook that can tell this
+    # engine's files from the host's.
+    #
+    # Basenames whose spelling this engine cannot express through default
+    # camelization (a genuine acronym it wants uppercased) go in OVERRIDES.
     initializer "action_agent.inflections", before: :set_autoload_paths do
-      engine_root = root.to_s
+      engine_root = File.join(root.to_s, "")
+      default = Zeitwerk::Inflector.new
 
       Rails.autoloaders.main.inflector.singleton_class.prepend(Module.new do
         define_method(:camelize) do |basename, abspath|
-          next "Api" if basename == "api" && abspath.to_s.start_with?(engine_root)
+          next super(basename, abspath) unless abspath.to_s.start_with?(engine_root)
 
-          super(basename, abspath)
+          ActionAgent::Engine::INFLECTION_OVERRIDES.fetch(basename) { default.camelize(basename, abspath) }
         end
       end)
     end
@@ -59,13 +74,33 @@ module ActionAgent
     # So the namespace answers to both. `const_missing` rather than an eager
     # alias because the controllers are autoloaded on demand, and naming them at
     # boot would load the whole dashboard.
-    ActionAgent.singleton_class.prepend(Module.new do
+    # The router does not consult the autoloader's inflector, so an acronym
+    # host asks for ActionAgent::API::MCPServersController while the constants
+    # are Api::McpServersController. Rather than enumerate the pairs, an
+    # all-caps run in a missing constant is retried in the spelling default
+    # camelization produces: API -> Api, MCPServersController -> McpServers-
+    # Controller. Only the engine's own namespaces are touched, and only for a
+    # constant that is already missing.
+    inflection_shim = Module.new do
       def const_missing(name)
-        return const_get(:Api) if name == :API
+        relaxed = name.to_s.gsub(/([A-Z])([A-Z]+)(?=[A-Z][a-z]|\d|\z)/) { "#{$1}#{$2.downcase}" }
 
-        super
+        return super if relaxed == name.to_s || !const_defined?(relaxed, false)
+
+        const_get(relaxed, false)
       end
-    end)
+    end
+
+    ActionAgent.singleton_class.prepend(inflection_shim)
+
+    # ActionAgent::Api is autoloaded, so it cannot be reopened at this point.
+    # Zeitwerk hands it over as soon as it is defined, which is before the
+    # router can ask it for a controller.
+    initializer "action_agent.api_inflection_shim" do
+      Rails.autoloaders.main.on_load("ActionAgent::Api") do |mod, _abspath|
+        mod.singleton_class.prepend(inflection_shim)
+      end
+    end
 
     initializer "action_agent.assets", before: :append_assets_path do |app|
       builds = root.join("app", "assets", "builds").to_s

--- a/actionagent/lib/action_agent/version.rb
+++ b/actionagent/lib/action_agent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActionAgent
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
1.2.1 fixed the `api` directory and nothing else. Seven files in this engine camelize differently once the host registers an acronym, and each raises `Zeitwerk::NameError` on first reference:

| file | host with acronym expects | file defines |
|---|---|---|
| `mcp_catalog.rb` | `MCPCatalog` | `McpCatalog` |
| `mcp_recording_middleware.rb` | `MCPRecordingMiddleware` | `McpRecordingMiddleware` |
| `playwright_mcp_client.rb` | `PlaywrightMCPClient` | `PlaywrightMcpClient` |
| `api_key.rb` | `APIKey` | `ApiKey` |
| `api_keys_controller.rb` | `APIKeysController` | `ApiKeysController` |
| `mcp_controller.rb` | `MCPController` | `McpController` |
| `mcp_servers_controller.rb` | `MCPServersController` | `McpServersController` |

Found by clicking through the mounted dashboard in a Rails 8.1 app that declares both `inflect.acronym "API"` and `inflect.acronym "MCP"`. The **Tools view is completely unreachable** there — it 500s with `uninitialized constant ActionAgent::ToolDiscovery::McpCatalog` — as are the MCP endpoints and anything touching an API key. Those are not exotic acronyms to register; Rails documents the pattern, and any host with its own MCP integration will have hit this.

### The fix

Rather than enumerate names, **every path under this engine now camelizes with Zeitwerk's default inflector**, ignoring whatever acronyms the host registered. It stays scoped by path, because the loader is shared with the host, whose own constants must keep their spelling.

`INFLECTION_OVERRIDES` carries any basename this engine wants spelled differently. It is empty today, which is the point: the engine names its files for the constants default camelization produces, and a file that wants a genuine acronym adds itself there rather than depending on the host.

The router half generalizes the same way. Routing does not consult the autoloader's inflector, so an acronym host asks for `ActionAgent::API::MCPServersController`. An all-caps run in a *missing* constant is now retried in the relaxed spelling (`API` → `Api`, `MCPServersController` → `McpServersController`) instead of aliasing each pair by hand.

### Verification

Installed into that host and clicked every dashboard view. Before: Tools 500s. After: **Tools renders** (2 tools detected, 6 calls, 0 errors, attributed to the right telemetry spans), and **MCP Services lists all 10 catalog entries** — the view that reads `McpCatalog` directly. Traces, Interactions and Metrics render throughout.

Screenshots of the before/after are in the linked Sparkle PR.


### Releases as 1.2.2

1.2.1 is already on RubyGems, so this ships as **1.2.2** — a host pinning `>= 1.2.1` picks the fix up on its next `bundle update`. Until it is released, the Tools and MCP Services views 500 on any host that registers these acronyms; Traces, Interactions and Metrics are unaffected.

Note for whoever cuts the release: `activeagent` stays at 1.2.0 here, and the publish step added in 1.2.1 skips a version already on RubyGems, so a `v1.2.2` tag publishes `actionagent` alone rather than failing on the duplicate.
