### PR TITLE
fix(actionagent): register observed agents when a trace is ingested

### DIFF
--- a/actionagent/app/models/action_agent/telemetry_trace.rb
+++ b/actionagent/app/models/action_agent/telemetry_trace.rb
@@ -135,7 +135,7 @@ module ActionAgent
       # Add account if in multi-tenant mode
       attrs[:account] = account if ActionAgent.multi_tenant? && account
 
-      create!(attrs)
+      create!(attrs).tap { |record| AgentRegistrar.call(record) }
     end
 
     # Sums a span's token counts (used to decide which spans carry the

--- a/actionagent/test/telemetry_trace_test.rb
+++ b/actionagent/test/telemetry_trace_test.rb
@@ -191,6 +191,47 @@ class TelemetryTraceTest < ActiveSupport::TestCase
     assert_empty trace.declared_tools
     assert_empty trace.mcp_servers
   end
+
+  # Ingest is the only place an agent running in a host app can be discovered:
+  # it never authors a record in the dashboard, it only reports traces. Without
+  # registration here the Agents list reads 0 while Traces and Interactions are
+  # full of that agent's runs, and nothing — per-agent metrics, evaluations,
+  # versions — has an agent to hang off.
+  test "registers an agent for the action it observes" do
+    ActionAgent::Agent.delete_all
+
+    trace = ActionAgent::TelemetryTrace.create_from_payload(payload(spans: [ root_span ]))
+
+    agent = ActionAgent::Agent.find_by(agent_class_name: "SupportAgent", action_name: "respond")
+    assert agent, "ingest should register the observed agent"
+    assert_equal "observed", agent.status
+    assert_equal agent.id, trace.reload.agent_id, "the trace should be attributed to it"
+  end
+
+  test "reuses the agent record across repeated ingests" do
+    ActionAgent::Agent.delete_all
+
+    2.times { ActionAgent::TelemetryTrace.create_from_payload(payload(spans: [ root_span ])) }
+
+    assert_equal 1, ActionAgent::Agent.where(agent_class_name: "SupportAgent").count
+  end
+
+  # Exercises AgentRegistrar's own rescue rather than a stub of it: a broken
+  # registration must never cost a host app its telemetry.
+  test "registration failure does not fail ingest" do
+    ActionAgent::Agent.delete_all
+    exploding = Object.new
+    def exploding.call = raise("boom")
+
+    ActionAgent::AgentRegistrar.stub(:new, exploding) do
+      trace = nil
+      assert_nothing_raised do
+        trace = ActionAgent::TelemetryTrace.create_from_payload(payload(spans: [ root_span ]))
+      end
+      assert trace.persisted?, "the trace should still be stored"
+      assert_nil trace.reload.agent_id
+    end
+  end
 end
 
 TelemetryTraceTest.ensure_table!


### PR DESCRIPTION
## The bug

A self-hosted mount shows **Agents: 0** while Traces and Interactions are full of that agent's runs.

`AgentRegistrar` has shipped with the engine since the split, is well written (identity is `(owner, service_name, agent_class, action_name)`, caps observed records per owner, adopts the winner on a concurrent `RecordNotUnique`, never raises) — and is **never called**. It appears only in comments.

Its own docstring describes the exact failure:

> Agents authored in the dashboard have records; agents running inside a customer's own app only ever reported traces, so the Agents list read 0 while Traces and Interactions were full of their runs.

## Why it matters beyond the count

`agent_id` stays null on every ingested trace, so everything that scopes to an agent is empty: per-agent Traces, Interactions, Metrics, Evals, Versions, and the agent detail page itself. For a host app reporting telemetry — the whole self-hosted story — the Agents section is inert.

## The fix

One line in `create_from_payload`, which is the single funnel every ingest path already goes through: the API controller, `ProcessTelemetryTracesJob`, `AgentExecutionService`, and the `local_storage` store.

```ruby
create!(attrs).tap { |record| AgentRegistrar.call(record) }
```

## Note on the platform app

`activeagents.ai` carries this as a workaround in its own `TelemetryTrace` subclass, which is why the hosted dashboard lists agents and a self-hosted mount does not. That override can be dropped once this ships.

## Verification

Against a self-hosted mount with `local_storage: true`, starting from an empty telemetry DB:

- Ran `CourseBuilderChatAgent` (2 turns) and `QuizBlueprintAgent` (1) from a host app
- Both registered themselves with correct `agent_class_name` / `action_name`, status `observed`
- Every trace came back with `agent_id` set
- Agent pages, per-agent Traces and per-agent Interactions all populated
- A tool-calling turn then surfaced in the Tools view (`regenerate_quiz`, calls=1), which also depends on this attribution

Distinct actions on one class register separately, as designed — `DocumentEnrichmentAgent.extract_page_summaries_batch` and `.extract_document_sections` are different agents.

## Tests

Three added to `actionagent/test/telemetry_trace_test.rb`: registration on ingest with attribution, reuse across repeated ingests, and that a registration failure does not fail ingest. The last stubs `AgentRegistrar.new` rather than `.call`, so the real rescue runs instead of the stub.

⚠️ **Not run locally** — the dummy app's encrypted credentials fail to decrypt in my checkout (`ActiveSupport::MessageEncryptor::InvalidMessage`, no master key), which breaks existing tests on a clean tree too. Relying on CI here.

## Risk

Low, and bounded by the registrar's own guarantees: it never raises, so a registration failure cannot cost a host app its telemetry; `MAX_OBSERVED_PER_OWNER` bounds runaway creation from a misconfigured reporter; and it returns early when `agent_id` is already set, so re-ingest is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)