### PR TITLE
Fix the docs deploy: a colon in a test name breaks artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ jobs:
   # activeagent + actionagent against solid_agent, in both the combination
   # this repository develops against and the one users install today. See
   # .github/workflows/integration.yml.
+  #
+  # Pull requests only: on main that workflow triggers itself, so its runs
+  # are attributed to it and its status badge means something.
   integration:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/integration.yml
     secrets: inherit
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,13 @@ on:
     types: [ solid-agent-changed ]
   schedule:
     - cron: "0 6 * * *"
+  # Runs here rather than through ci.yml on main. A workflow_call run is
+  # attributed to the caller, so this workflow had no runs of its own and
+  # its status badge read "no status" however often the suite passed.
+  # ci.yml keeps calling it for pull requests, where the badge is irrelevant
+  # and one combined check is what reviewers want.
+  push:
+    branches: [ main ]
 
 jobs:
   integration:

--- a/docs/actions/delegation.md
+++ b/docs/actions/delegation.md
@@ -139,7 +139,7 @@ delegate_to KnowledgeBaseAgent, budget: { max_calls: 3, max_tokens: 20_000 }
 
 Both apply — a call has to clear the agent-wide ceiling *and* its own limit.
 
-<!-- @include: @/parts/examples/delegation-examples-test.rb-test-budgets-layer:-the-agent-wide-ceiling-and-the-per-delegation-limit.md -->
+<!-- @include: @/parts/examples/delegation-examples-test.rb-test-budgets-layer--the-agent-wide-ceiling-and-the-per-delegation-limit.md -->
 
 | Limit | Unit | Meaning |
 |:------|:-----|:--------|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,18 @@ def extract_path_info(caller_info)
   end
 end
 
+# Test names become filenames, and those filenames become artifact paths on
+# the docs deploy. actions/upload-artifact rejects a handful of characters
+# outright — a colon in one test name failed every Pages deploy from the
+# moment it was added, after the docs themselves had built fine.
+#
+# The rejected set is the action's own: " : < > | * ? \r \n
+DOC_EXAMPLE_UNSAFE_CHARACTERS = /["*:<>?|\r\n]/
+
+def doc_example_filename_safe(name)
+  name.to_s.gsub(DOC_EXAMPLE_UNSAFE_CHARACTERS, "-")
+end
+
 def doc_example_output(example = nil, test_name = nil)
   # Extract caller information
   caller_info = caller.find { |line| line.include?("_test.rb") }
@@ -49,8 +61,9 @@ def doc_example_output(example = nil, test_name = nil)
   end
 
   path_info = extract_path_info(caller_info)
-  file_name = path_info[:file_name].dasherize
+  file_name = doc_example_filename_safe(path_info[:file_name].dasherize)
   test_name ||= name.to_s.dasherize if respond_to?(:name)
+  test_name = doc_example_filename_safe(test_name)
 
   file_path = Rails.root.join("..", "..", "docs", "parts", "examples", "#{file_name}-#{test_name}.md")
   # puts "\nWriting example output to #{file_path}\n"


### PR DESCRIPTION
**docs.activeagents.ai has not deployed since Aug 14.** Every `Deploy VitePress site to Pages` run on `main` has failed since #360 — five in a row, including the merge of #364, so the site is still serving pre-delegation content and the SolidAgent section isn't live.

## What's wrong

The site builds fine. `build-current` then dies on the upload:

```
##[error] The path for one of the files in artifact is not valid:
/parts/examples/delegation-examples-test.rb-test-budgets-layer:-the-agent-wide-ceiling-and-the-per-delegation-limit.html
Contains the following character:  Colon :
```

`doc_example_output` names its output file after the test method. `test "budgets layer: the agent-wide ceiling and the per-delegation limit"` keeps its colon through `dasherize`, VitePress renders a page at that path, and `actions/upload-artifact` refuses the characters NTFS can't store (`" : < > | * ? \r \n`). One bad name rejects the entire artifact, `deploy` skips, and nothing ships.

The `build-versioned (0.6.3)` job passes throughout, which is why the run looks half-healthy.

## Fix

Sanitize in the helper, not by renaming the test:

```ruby
DOC_EXAMPLE_UNSAFE_CHARACTERS = /["*:<>?|\r\n]/

def doc_example_filename_safe(name)
  name.to_s.gsub(DOC_EXAMPLE_UNSAFE_CHARACTERS, "-")
end
```

Renaming the one test would unbreak today and break again the next time someone writes a colon in a test name — and the failure message points at an artifact path, not at the test that produced it. The single `@include` referencing the old filename moves with it.

## Also: the "no status" integration badge

`integration.yml` was only reachable through `workflow_call` from `ci.yml`, and GitHub attributes a called run to the caller — so it had no runs of its own and its README badge read `no status` no matter how often the suite passed. It now triggers itself on `main`, and `ci.yml` calls it for pull requests only: one combined check per PR, and a badge that reflects main.

## Testing

- Regenerated every doc example and scanned: no filename under `docs/parts/examples/` contains a rejected character
- `npm run docs:build` clean; `find docs/.vitepress/dist -name '*[":<>?|*]*'` returns 0 — the exact condition that failed
- `bin/rubocop` clean (460 files)

The proof this works is the deploy run on merge, since the failure only reproduces inside `upload-artifact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGn2NzpzFZT4JGKBdFMpxh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGn2NzpzFZT4JGKBdFMpxh)_