### PR TITLE
Release activeagent 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-18
+
+### Added
+
+- **Agent-as-tool delegation.** A tool is a Ruby method the model can call; a
+  delegation is another agent it can call. The callee keeps its own
+  instructions, templates, model and budget, so a specialist agent stays
+  specialist and the generalist orchestrating it never inherits its prompt.
+  Declared with `delegation :action, description:` on the sub-agent, with a
+  JSON Schema for the inputs and an optional `returns` schema that becomes the
+  sub-agent's response format. See `docs/actions/delegation.md`.
+
+### Fixed
+
+- **Streamed generations report their token usage.** A request with
+  `stream: true` recorded zero input and output tokens, and so zero cost and
+  no context-pressure estimate downstream — dashboards showed `Tokens 0` and
+  `$0.00` beside a run that had plainly called the API. Three things had to
+  hold at once for the usage to survive, and none did: the streaming path
+  returns `nil` rather than a response body to read usage from; Chat
+  Completions only emits its usage chunk when the request sets
+  `stream_options: {include_usage: true}`, which was never sent; and that
+  chunk arrives *after* `content.done`, where the response was already being
+  built. Completion now defers until the stream drains, and the usage chunk
+  is recorded on the way past. A provider hook (`api_stream_usage_parameters`,
+  empty by default) keeps providers that report unconditionally — or not at
+  all — unaffected.
+
+  Also fixed a silent conversion failure behind the same symptom:
+  `Usage.from_provider_usage` early-returns on anything that is not a Hash,
+  and the stainless gems hand back model objects, so usage was dropped even
+  when it did arrive.
+
+### Note on the 1.2.0 tag
+
+The `v1.2.0` tag had been moved to a commit later than the one published as
+`activeagent 1.2.0`, so the tag and the gem disagreed. It has been repointed
+to the commit that actually produced the release. If you fetched the tag
+between 2026-08-14 and 2026-08-18, re-fetch with `git fetch --tags --force`.
+
 ## [1.2.2] - 2026-08-14
 
 ### Fixed

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
## Why

`activeagent` is still published at **1.2.0** while `actionagent` has shipped 1.2.1 and 1.2.2. Two changes have sat on main unreleased since, and one is a bug that makes the dashboard misreport every streamed run.

| | on main | published |
|---|---|---|
| agent-as-tool delegation (#360) | ✅ | ❌ |
| streaming token usage (#362) | ✅ | ❌ |

Verified by unpacking the published gem: `record_stream_usage` is absent from `activeagent-1.2.0`, and `lib/active_agent/delegation/` does not exist in it.

## Why minor, not patch

Delegation adds a public DSL (`delegation :action, description:`) and a new `lib/active_agent/delegation/` tree. Shipping a new core primitive under a patch version hides it from anyone reading the changelog to decide whether to upgrade.

## The bug this unblocks

A `stream: true` generation reports **zero tokens and zero cost**, and the context-pressure estimate that depends on them never renders. On a self-hosted dashboard that means an empty Tokens column and `$0.00` beside runs that plainly called the API.

Confirmed end to end against OpenRouter (`anthropic/claude-sonnet-4.5`): a streamed probe went from `usage=nil` to `input=14 output=4`, matching the same prompt issued non-streaming, and a real 30-page document-enrichment batch went from `0/0` to `475/72`.

## The v1.2.0 tag

The tag had drifted to `094ebe79` (#364) — later than the commit actually published as the 1.2.0 gem — so `git diff v1.2.0..main` showed nothing outstanding when in fact two changes were. It is repointed here to `147418c8`, verified byte-identical to the published gem across `lib/active_agent.rb`, `base.rb` and `_base_provider.rb`.

⚠️ The tag move must be pushed with `git push --force origin v1.2.0`, and anyone who fetched it in the meantime needs `git fetch --tags --force`.

## Compatibility

`actionagent`'s `>= 1.2, < 2` constraint already accepts 1.3.0, so no coordinated bump is needed.

## Checklist before merging

- [ ] CI green
- [ ] `git push --force origin v1.2.0` (tag repoint)
- [ ] Tag `v1.3.0` after merge
- [ ] Confirm the release workflow publishes both gems in dependency order

🤖 Generated with [Claude Code](https://claude.com/claude-code)