### PR TITLE
fix: record the user turn an agent renders from its template

### DIFF
--- a/lib/active_agent/telemetry/instrumentation.rb
+++ b/lib/active_agent/telemetry/instrumentation.rb
@@ -94,12 +94,24 @@ module ActiveAgent
                 prompt_span.set_attribute("prompt.input.tools", JSON.generate(roster)) if roster.any?
               end
 
-              if (outbound = prompt_options[:messages]).present?
+              # prompt_options[:messages] holds the turns a caller passed
+              # explicitly. An agent that renders its user turn from the
+              # action's template — the idiomatic form, `instructions:` plus
+              # `locals:` — has none at this point: the rendering happens
+              # later, in prepare_prompt_parameters. Falling back to it means
+              # the message the model actually received is on the trace either
+              # way, which is what an evaluation scores.
+              outbound = prompt_options[:messages]
+              outbound = rendered_prompt_messages if outbound.blank?
+
+              if outbound.present?
                 serialized = Array(outbound).map { |message|
                   if message.is_a?(Hash)
                     role = message[:role] || message["role"] || "user"
                     content = message[:content] || message["content"]
                     { role: role.to_s, content: telemetry_truncate(content) }
+                  elsif message.respond_to?(:content)
+                    { role: (message.try(:role) || "user").to_s, content: telemetry_truncate(message.content) }
                   else
                     { role: "user", content: telemetry_truncate(message) }
                   end
@@ -256,6 +268,27 @@ module ActiveAgent
         # Content attributes are capped so a large prompt (e.g. a 100k-token
         # tool loop) can't bloat the trace payload.
         TELEMETRY_ATTRIBUTE_MAX_CHARS = 4_000
+
+        # The turns this generation will actually send, for an agent that
+        # renders its user message from the action's template rather than
+        # passing `messages:`. prepare_prompt_parameters is a pure function of
+        # prompt_options — it deep_dups its input and mutates no instance
+        # state — so calling it here is a read, not a side effect. It does
+        # re-render the templates, which is why it is only reached when there
+        # are no explicit messages to record.
+        #
+        # Never raises: a provider that builds parameters differently, or an
+        # agent whose templates need context this call does not have, must
+        # cost the generation nothing more than an absent attribute.
+        def rendered_prompt_messages
+          return unless respond_to?(:prepare_prompt_parameters, true)
+
+          parameters = prepare_prompt_parameters
+          parameters[:messages] || parameters["messages"]
+        rescue StandardError => e
+          logger&.debug { "[ActiveAgent::Telemetry] could not read rendered messages: #{e.class}: #{e.message}" }
+          nil
+        end
 
         def telemetry_truncate(value)
           text = value.to_s

--- a/test/telemetry/rendered_messages_test.rb
+++ b/test/telemetry/rendered_messages_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# An agent that renders its user turn from the action's template — the
+# idiomatic `instructions:` + `locals:` form — passes no `messages:`, so the
+# instrumentation had nothing to record and `prompt.input.messages` was absent
+# from its traces. The system prompt and the completion were both captured,
+# which made the gap easy to miss: a trace looked populated while the half an
+# evaluation scores, what the user actually said, was missing.
+class RenderedMessagesTest < ActiveSupport::TestCase
+  class Recorder
+    attr_reader :attributes
+
+    def initialize = @attributes = {}
+    def set_attribute(key, value) = @attributes[key] = value
+  end
+
+  # Stands in for an agent whose messages only exist once the templates run.
+  class TemplateRenderingAgent
+    include ActiveAgent::Telemetry::Instrumentation::GenerationInstrumentation
+
+    def initialize(rendered:, explicit: nil, raises: false)
+      @rendered = rendered
+      @explicit = explicit
+      @raises = raises
+    end
+
+    def prompt_options = { messages: @explicit }.compact
+
+    def prepare_prompt_parameters
+      raise "templates unavailable" if @raises
+
+      { messages: @rendered }
+    end
+
+    def logger = nil
+  end
+
+  def messages_for(agent)
+    agent.send(:rendered_prompt_messages)
+  end
+
+  test "reads the messages the templates rendered" do
+    agent = TemplateRenderingAgent.new(rendered: [ { role: "user", content: "rendered turn" } ])
+
+    assert_equal [ { role: "user", content: "rendered turn" } ], messages_for(agent)
+  end
+
+  test "a failure to render costs the generation nothing but the attribute" do
+    agent = TemplateRenderingAgent.new(rendered: nil, raises: true)
+
+    assert_nil messages_for(agent)
+  end
+
+  test "an agent without prepare_prompt_parameters is left alone" do
+    bare = Class.new do
+      include ActiveAgent::Telemetry::Instrumentation::GenerationInstrumentation
+      def logger = nil
+    end.new
+
+    assert_nil bare.send(:rendered_prompt_messages)
+  end
+end


### PR DESCRIPTION
## The gap

A trace from a template-rendering agent carries `prompt.input.instructions` and `llm.output.message` but **not** `prompt.input.messages`. The user turn — what the model was actually asked — is missing.

Easy to miss, because the other two attributes are there: the trace looks populated, the Conversation tab renders System and Assistant, and only the User row is absent. It is also the half an evaluation scores.

## Why

The instrumentation serializes `prompt_options[:messages]`, which holds turns a caller passed explicitly. An agent written the idiomatic way —

```ruby
prompt(
  instructions: { template: "instructions_summaries_batch", locals: shared_locals },
  locals: shared_locals
)
```

— has none at that point. Its user turn is rendered later, in `prepare_prompt_parameters`. So the message reaches the model and never reaches the trace.

## The fix

Fall back to the rendered parameters when there are no explicit messages.

`prepare_prompt_parameters` is a pure function of `prompt_options` — it `deep_dup`s its input and mutates no instance state — so reading it is safe. It does re-render the templates, which is why the fallback is only reached when there is nothing else to record. It never raises: an agent whose templates need context this call cannot supply loses the attribute, not the generation.

Also handles message objects responding to `#content`, not just hashes and strings, since that is what the rendered parameters contain.

## Verification

Against a self-hosted dashboard, same agent, stock gems before and after:

| attribute | before | after |
|---|---|---|
| `prompt.input.instructions` | ✅ | ✅ |
| `prompt.input.messages` | ❌ | ✅ |
| `llm.output.message` | ✅ | ✅ |

The captured turn is the real rendered content (`"Title: Emergency shutdown procedure\nDocument id: …"`), and the trace's Conversation tab now shows System / User / Assistant.

An app-side workaround for exactly this had accumulated in a host app's `ApplicationAgent` — hooking `prepare_prompt_parameters` and writing the gem's own attribute name. Removing it and relying on this change reproduces the same result, which is the outcome that matters: apps should not each have to discover and patch this.

## Tests

`test/telemetry/rendered_messages_test.rb` covers reading the rendered messages, failing safe when rendering raises, and skipping agents that do not implement `prepare_prompt_parameters`.

⚠️ **Not run in the repo's harness** — the dummy app's encrypted credentials fail to decrypt in my checkout (`ActiveSupport::MessageEncryptor::InvalidMessage`, no master key), which breaks existing tests on a clean tree too. The three behaviours were verified directly against the module in a host app's console instead; CI should be the judge of the file itself.

## Risk

Confined to the telemetry path and only reached when `prompt_options[:messages]` is blank — an agent that passes messages explicitly takes the existing branch unchanged. The extra template render costs one pass, and only for agents that were previously recording nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)