### PR TITLE
Release activeagent 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-08-19
+
+### Fixed
+
+- **Traces record the user turn an agent renders from its template.** An
+  agent written the idiomatic way — `instructions:` plus `locals:`, with the
+  user message in the action's ERB — passed no `messages:`, so the
+  instrumentation had nothing to serialize and `prompt.input.messages` was
+  absent from its traces. The system prompt and the completion were both
+  captured, which made the gap easy to miss: a trace looked populated while
+  the half an evaluation scores, what the model was actually asked, was
+  missing. The instrumentation now falls back to the rendered parameters when
+  no explicit messages exist.
+
+### Note on the 1.3.0 gem
+
+`activeagent 1.3.0` was published from a tree that already carried the fix
+above, so the released gem did not match the `v1.3.0` tag — the tag's source
+would not reproduce it. This release contains no change relative to that
+published gem; it exists so that the tag, `main` and the published gem agree
+again. Upgrading from 1.3.0 is optional and changes no behaviour.
+
 ## [1.3.0] - 2026-08-18
 
 ### Added

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
## Why

Ships #367 under a version whose tag actually produces it.

**1.3.0 was published from a tree that already carried #367 while the PR was still open**, so the released gem and the `v1.3.0` tag disagree — building from the tag yields a different artifact than the one on rubygems.org. Exactly one file differs (`lib/active_agent/telemetry/instrumentation.rb`); nothing else leaked.

| | has #367 |
|---|---|
| tag `v1.3.0` | ❌ |
| published gem 1.3.0 | ✅ |
| `main` (now #367 is merged) | ✅ |

## No functional change

`main` is now **byte-identical** to the published 1.3.0 gem across `lib/`, verified file by file. Upgrading from 1.3.0 changes no behaviour. This release exists so the tag, `main` and the gem agree again.

## What #367 fixed, for the changelog record

An agent written the idiomatic way — `instructions:` plus `locals:`, user message in the action's ERB — passed no `messages:`, so `prompt.input.messages` was absent from its traces. The system prompt and completion were both captured, which made it easy to miss: the trace looked populated while the half an evaluation scores was missing.

## Verification

A host app on published `activeagent 1.3.0` + `actionagent 1.2.2` + `solid_agent 0.2.0` + `activeagents-telemetry 0.2.0`, no path or git sources:

| trace | agent registered | tokens | content |
|---|---|---|---|
| non-streaming chat | ✅ | 2676/184 | 3/3 |
| tool-calling chat | ✅ | 5519/151 | 3/3 |
| streaming enrichment | ✅ | 475/97 | 3/3 |

All three attributes (`prompt.input.instructions`, `prompt.input.messages`, `llm.output.message`) present on every trace, agents auto-registered, tools discovered, tool call captured. The host app's suite: 1232 runs, 4838 assertions, 0 failures.

An app-side workaround for the missing user turn was removed from that host and the behaviour held — which is the point: apps should not each have to discover and patch this.

## Checklist

- [ ] CI green
- [ ] Tag `v1.3.1` after merge
- [ ] Confirm the release workflow publishes from the tag, not a working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)