### PR TITLE
chore: remove client names from comments and docs

### DIFF
--- a/actionagent/app/services/action_agent/agent_registrar.rb
+++ b/actionagent/app/services/action_agent/agent_registrar.rb
@@ -10,9 +10,10 @@ module ActionAgent
   # metrics can hang off.
   #
   # Identity is (account, service_name, agent_class, agent_action) — one agent
-  # per action, not per class. Clara.respond (admin assistant, every MCP tool,
-  # ~$0.03/run) and Clara.title (no tools, temperature 0.2, ~$0.0004/run) are
-  # different agents that share a class name because one app method spawns both.
+  # per action, not per class. Assistant.respond (admin assistant, every MCP
+  # tool, ~$0.03/run) and Assistant.title (no tools, temperature 0.2,
+  # ~$0.0004/run) are different agents that share a class name because one app
+  # method spawns both.
   # Collapsing them would blend a $0.03 agent with a $0.0004 one into a single
   # meaningless cost-per-run.
   #
@@ -60,7 +61,7 @@ module ActionAgent
       @trace.agent_action.presence
     end
 
-    # Name carries the action so the two Claras are distinguishable anywhere a
+    # Name carries the action so the two agents are distinguishable anywhere a
     # bare agent name is shown.
     def display_name
       action_name ? "#{agent_class}.#{action_name}" : agent_class
@@ -138,8 +139,8 @@ module ActionAgent
 
     # Config we can only learn by watching: the model actually used, the
     # instructions actually sent (when content capture is on), and the tools
-    # actually called — which is how Clara.respond acquires a tool list while
-    # Clara.title correctly stays empty.
+    # actually called — which is how Assistant.respond acquires a tool list while
+    # Assistant.title correctly stays empty.
     def llm_attribute(key)
       spans.filter_map { |span| span.dig("attributes", key).presence }.first
     end

--- a/actionagent/frontend/components/dashboard/InteractionsView.jsx
+++ b/actionagent/frontend/components/dashboard/InteractionsView.jsx
@@ -312,8 +312,8 @@ export default function InteractionsView({ agentId = null, embedded = false }) {
     }
   }, [sortBy]);
 
-  // Group by Agent.action, not by agent class. Clara.respond (admin assistant,
-  // full tool access, ~$0.03/run) and Clara.title (no tools, temperature 0.2,
+  // Group by Agent.action, not by agent class. Assistant.respond (admin assistant,
+  // full tool access, ~$0.03/run) and Assistant.title (no tools, temperature 0.2,
   // ~$0.0004/run) are different agents that share a class name because one app
   // method spawns both; interleaving their streams hides that.
   const agentGroups = useMemo(() => {
@@ -533,7 +533,7 @@ export default function InteractionsView({ agentId = null, embedded = false }) {
         <div className="space-y-8">
           {agentGroups.map((group) => (
           <div key={group.key} className="space-y-4">
-            {/* Agent header — Clara.respond and Clara.title are different
+            {/* Agent header — Assistant.respond and Assistant.title are different
                 agents (different instructions, tools, cost), so their streams
                 are grouped rather than interleaved. */}
             <div className="flex items-baseline justify-between">

--- a/docs/framework/self-hosted-observability.md
+++ b/docs/framework/self-hosted-observability.md
@@ -99,15 +99,15 @@ to the full URL, as shown below, and `resolved_endpoint` returns that.)
 # A path on your main app:
 mount ActionAgent::Engine => "/activeagents"
 
-# Or the root of a dedicated subdomain, e.g. activeagents.combinaut.com:
+# Or the root of a dedicated subdomain, e.g. activeagents.example.com:
 constraints subdomain: "activeagents" do
   mount ActionAgent::Engine => "/", as: :active_agent_subdomain
 end
 ```
 
 With the subdomain mount, the dashboard lives at
-`https://activeagents.combinaut.com/` and remote apps post traces to
-`https://activeagents.combinaut.com/api/traces`.
+`https://activeagents.example.com/` and remote apps post traces to
+`https://activeagents.example.com/api/traces`.
 
 ## Authentication (required in production)
 
@@ -161,7 +161,7 @@ mount:
 production:
   telemetry:
     enabled: true
-    endpoint: https://activeagents.combinaut.com/api/traces
+    endpoint: https://activeagents.example.com/api/traces
     api_key: <%= Rails.application.credentials.dig(:active_agent, :ingest_api_key) %>
 ```
 
@@ -202,7 +202,7 @@ gem "activeagents-telemetry-ruby_llm"
 ```ruby
 # config/initializers/ruby_llm_telemetry.rb
 ActiveAgents::Telemetry::RubyLLM.subscribe!(
-  endpoint: "https://activeagents.combinaut.com/api/traces",
+  endpoint: "https://activeagents.example.com/api/traces",
   api_key: Rails.application.credentials.dig(:active_agent, :ingest_api_key),
   service_name: "billing-app"
 )


### PR DESCRIPTION
Replaces client-identifying names in dashboard code comments and the self-hosted observability guide with generic examples:

- `AgentRegistrar` and `InteractionsView.jsx` comments now use `Assistant.respond` / `Assistant.title` as the two-actions-one-class example.
- `docs/framework/self-hosted-observability.md` example mounts now use `activeagents.example.com`.

No behavior changes — comments and docs only. Companion cleanup in the activeagents app repo is staged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)