### PR TITLE
fix: load RubyLLM when the gem registers its acronym

### DIFF
--- a/lib/active_agent/providers/rubyllm_provider.rb
+++ b/lib/active_agent/providers/rubyllm_provider.rb
@@ -1,0 +1,1 @@
+require_relative "ruby_llm_provider"


### PR DESCRIPTION
## Summary
In a Rails app that bundles the `ruby_llm` gem, `service: "RubyLLM"` fails while loading the provider.

## Bug
`provider_load` requires `active_agent/providers/#{service_name.underscore}_provider`. 
The `ruby_llm` gem's railtie registers `inflect.acronym "RubyLLM"`, so `"RubyLLM".underscore` becomes `rubyllm` and ActiveAgent looks for a missing file.

```
Failed to load provider ruby_llm: cannot load such file -- active_agent/providers/rubyllm_provider (RuntimeError)
```

## Why fix it
Using the RubyLLM provider requires the `ruby_llm` gem, and that gem's Rails railtie registers the acronym. Real apps need `service: "RubyLLM"` to load.

## How we fixed it
Added `lib/active_agent/providers/rubyllm_provider.rb` as a one-line alias of `ruby_llm_provider.rb`, matching `openai_provider.rb`.

## Test Plan
- A Rails app with `ruby_llm` can load an agent class that calls `generate_with :ruby_llm` with `service: "RubyLLM"`
- The LoadError above does not occur
- Existing `generate_with :ruby_llm` still loads `ruby_llm_provider.rb` when the ruby_llm railtie has not run

fixes #371