### PR TITLE
fix: return 405 for unsupported MCP methods

### DIFF
--- a/actionagent/config/routes.rb
+++ b/actionagent/config/routes.rb
@@ -135,6 +135,9 @@ ActionAgent::Engine.routes.draw do
   # dashboard API key rather than a session, so it sits outside the api
   # namespace's session-authenticated controllers.
   post "mcp", to: "api/mcp#create"
+  match "mcp", to: ->(_env) { [ 405, { "Allow" => "POST" }, [] ] },
+    via: [ :get, :delete ],
+    constraints: ->(request) { request.delete? || !request.format.html? }
 
   # Everything else under the mount is a client-side route: render the
   # dashboard and let the browser resolve it. Anchored last so it can only

--- a/actionagent/test/engine_integration_test.rb
+++ b/actionagent/test/engine_integration_test.rb
@@ -115,6 +115,25 @@ class DashboardEngineIntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "active-agent-dashboard"
   end
 
+  test "mcp endpoint rejects unsupported transport methods" do
+    get "/activeagents/mcp", headers: { "Accept" => "text/event-stream" }
+
+    assert_response :method_not_allowed
+    assert_equal "POST", response.headers["Allow"]
+
+    delete "/activeagents/mcp"
+
+    assert_response :method_not_allowed
+    assert_equal "POST", response.headers["Allow"]
+  end
+
+  test "mcp dashboard route still renders for browsers" do
+    get "/activeagents/mcp", headers: { "Accept" => "text/html" }
+
+    assert_response :success
+    assert_includes response.body, "active-agent-dashboard"
+  end
+
   test "dashboard refuses unauthenticated access in production when no auth is configured" do
     Rails.env.stub(:local?, false) do
       get "/activeagents/console/traces"


### PR DESCRIPTION
## Summary

- return `405 Method Not Allowed` with `Allow: POST` when an MCP transport client sends GET or DELETE to the Streamable HTTP endpoint
- preserve the existing `/mcp` dashboard deep link for browser requests that prefer HTML
- cover both protocol and browser behavior with integration tests

This addresses the MCP routing finding in #389. The separate catalog placeholder/tool-hint finding is intentionally out of scope.

## Validation

- `BUNDLE_GEMFILE=gemfiles/rails8.gemfile bundle exec ruby -Itest actionagent/test/engine_integration_test.rb` (36 runs, 180 assertions)
- `bundle exec rubocop actionagent/config/routes.rb actionagent/test/engine_integration_test.rb`