### PR TITLE
Stop average_score raising on comparison evaluation runs

### DIFF
--- a/actionagent/app/controllers/action_agent/api/evaluations_controller.rb
+++ b/actionagent/app/controllers/action_agent/api/evaluations_controller.rb
@@ -135,13 +135,25 @@ module ActionAgent
           id: run.id,
           status: run.status,
           scores: run.scores,
-          average_score: run.average_score,
+          average_score: safe_average_score(run),
           samples_evaluated: run.samples_evaluated,
           samples_passed: run.samples_passed,
           error_message: run.error_message,
           completed_at: run.completed_at&.iso8601,
           created_at: run.created_at.iso8601
         }
+      end
+
+      # index serializes the latest run of every listed evaluation, so an
+      # unaveragable scores payload used to 500 the entire Evaluations page
+      # instead of degrading that one run's headline number.
+      def safe_average_score(run)
+        run.average_score
+      rescue StandardError => e
+        Rails.logger.warn(
+          "[ActionAgent] evaluation run #{run.id} average_score failed: #{e.class}: #{e.message}"
+        )
+        nil
       end
     end
   end

--- a/actionagent/app/models/action_agent/evaluation_run.rb
+++ b/actionagent/app/models/action_agent/evaluation_run.rb
@@ -10,11 +10,35 @@ module ActionAgent
 
     scope :recent, -> { order(created_at: :desc) }
 
+    # scores is not uniformly { criterion => stats }: a comparison run also
+    # records "_"-prefixed metadata (EvaluationRunnerService writes
+    # "_missing_models" as an Array and "_verdict"), and each of its criteria
+    # is a cohort map of model => stats rather than a single stats hash.
+    # Only real criterion scores are averaged; anything else is ignored
+    # rather than raising and taking the whole Evaluations page down.
     def average_score
-      values = scores.values.map { |s| s["score"] }.compact
+      values = (scores || {}).reject { |key, _| key.to_s.start_with?("_") }.filter_map do |_key, value|
+        criterion_score(value) if value.is_a?(Hash)
+      end
       return nil if values.empty?
 
       (values.sum.to_f / values.size).round(3)
+    end
+
+    private
+
+    # A criterion is either scored directly ({ "score" => 0.8, ... }) or, on a
+    # comparison run, a map of model => stats; that cohort's mean is the
+    # criterion's headline score. Skipped criteria carry no score at all.
+    def criterion_score(value)
+      return value["score"] if value["score"].is_a?(Numeric)
+
+      cohort = value.each_value.filter_map do |stats|
+        stats["score"] if stats.is_a?(Hash) && stats["score"].is_a?(Numeric)
+      end
+      return nil if cohort.empty?
+
+      cohort.sum.to_f / cohort.size
     end
   end
 end

--- a/actionagent/test/evaluation_run_test.rb
+++ b/actionagent/test/evaluation_run_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# EvaluationRun#average_score reads a scores payload that is not uniformly
+# { criterion => stats }: a comparison run writes "_"-prefixed metadata and
+# cohort maps of model => stats alongside plain criterion hashes.
+class ActionAgentEvaluationRunTest < ActiveSupport::TestCase
+  def run_with(scores)
+    ActionAgent::EvaluationRun.new(scores: scores)
+  end
+
+  test "plain criterion stats are averaged" do
+    run = run_with(
+      "response_present" => { "score" => 1.0, "min" => 1.0, "max" => 1.0, "passed" => 2, "total" => 2 },
+      "latency" => { "score" => 0.5, "min" => 0.5, "max" => 0.5, "passed" => 0, "total" => 2 }
+    )
+
+    assert_in_delta 0.75, run.average_score, 0.0001
+  end
+
+  test "skipped criteria carry no score and drop out of the average" do
+    run = run_with(
+      "llm_judge" => { "skipped" => true, "reason" => "No judge provider configured" },
+      "latency" => { "score" => 0.4, "min" => 0.4, "max" => 0.4, "passed" => 0, "total" => 1 }
+    )
+
+    assert_in_delta 0.4, run.average_score, 0.0001
+  end
+
+  # Regression: EvaluationRunnerService#score_comparison writes
+  # scores["_missing_models"] = ["gpt-4o"] (an Array) for a comparison run
+  # whose cohorts have no generations. average_score used to call
+  # Array#[]("score"), raising TypeError and permanently 500-ing
+  # GET <mount>/api/evaluations.
+  test "_missing_models does not raise and is excluded from the average" do
+    run = run_with(
+      "response_present" => { "score" => 0.8, "min" => 0.8, "max" => 0.8, "passed" => 1, "total" => 1 },
+      "_missing_models" => [ "gpt-4o" ]
+    )
+
+    assert_nothing_raised { run.average_score }
+    assert_in_delta 0.8, run.average_score, 0.0001
+  end
+
+  test "underscore metadata alone averages to nil rather than raising" do
+    run = run_with("_missing_models" => [ "gpt-4o", "no-such-model" ])
+
+    assert_nil run.average_score
+  end
+
+  test "a comparison cohort map averages its per-model scores" do
+    run = run_with(
+      "response_present" => {
+        "gpt-4o-mini" => { "score" => 1.0, "min" => 1.0, "max" => 1.0, "passed" => 2, "total" => 2 },
+        "claude-haiku" => { "score" => 0.6, "min" => 0.6, "max" => 0.6, "passed" => 1, "total" => 2 }
+      }
+    )
+
+    assert_in_delta 0.8, run.average_score, 0.0001
+  end
+
+  test "a comparison run averages cohort maps alongside metadata and a verdict" do
+    run = run_with(
+      "response_present" => {
+        "gpt-4o-mini" => { "score" => 1.0, "total" => 2 },
+        "claude-haiku" => { "score" => 0.6, "total" => 2 }
+      },
+      "latency" => {
+        "gpt-4o-mini" => { "score" => 0.4, "total" => 2 },
+        "claude-haiku" => { "score" => 0.8, "total" => 2 }
+      },
+      "_missing_models" => [ "no-such-model" ],
+      "_verdict" => { "winner" => "gpt-4o-mini", "rationale" => "Fewer empty answers." }
+    )
+
+    # (1.0 + 0.6) / 2 = 0.8 and (0.4 + 0.8) / 2 = 0.6, averaged => 0.7
+    assert_in_delta 0.7, run.average_score, 0.0001
+  end
+
+  test "a cohort whose models were all skipped contributes no score" do
+    run = run_with(
+      "llm_judge" => {
+        "gpt-4o-mini" => { "skipped" => true, "reason" => "No judge provider configured" },
+        "claude-haiku" => { "skipped" => true, "reason" => "No judge provider configured" }
+      },
+      "latency" => { "score" => 0.9, "total" => 1 }
+    )
+
+    assert_in_delta 0.9, run.average_score, 0.0001
+  end
+
+  test "an empty scores payload averages to nil" do
+    assert_nil run_with({}).average_score
+  end
+end
+
+# The Evaluations index serializes the latest run of every listed evaluation,
+# so a single unaveragable run used to take the whole page down.
+class ActionAgentEvaluationsIndexTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionAgent::Agent.delete_all
+  end
+
+  test "the index survives a comparison run that records _missing_models" do
+    agent = ActionAgent::Agent.create!(name: "Comparer", provider: "openai", model: "gpt-4o-mini")
+    evaluation = agent.evaluations.create!(
+      name: "Model bake-off",
+      judge_kind: "rules",
+      criteria: [ { "key" => "response_present", "type" => "response_present", "config" => {} } ],
+      config: { "compare_models" => [ "gpt-4o-mini", "no-such-model" ] }
+    )
+    evaluation.evaluation_runs.create!(
+      status: :complete,
+      scores: {
+        "response_present" => {
+          "gpt-4o-mini" => { "score" => 1.0, "min" => 1.0, "max" => 1.0, "passed" => 2, "total" => 2 }
+        },
+        "_missing_models" => [ "no-such-model" ]
+      },
+      samples_evaluated: 2,
+      samples_passed: 2,
+      completed_at: Time.current
+    )
+
+    get "/activeagents/api/evaluations"
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    latest = body["evaluations"].first["latest_run"]
+    assert_in_delta 1.0, latest["average_score"], 0.0001
+    assert_equal [ "no-such-model" ], latest.dig("scores", "_missing_models")
+  end
+end


### PR DESCRIPTION
## What was broken

`ActionAgent::EvaluationRun#average_score` (`actionagent/app/models/action_agent/evaluation_run.rb:13-18`) mapped `s["score"]` over **every** value in the `scores` payload:

```ruby
values = scores.values.map { |s| s["score"] }.compact
```

But `scores` is not uniformly `{ criterion => stats }`. `EvaluationRunnerService#score_comparison` (`actionagent/app/services/action_agent/evaluation_runner_service.rb:104-106`) writes:

```ruby
scores["_missing_models"] = missing if missing.any?
```

— an **Array**. `Array#[]("score")` raises `TypeError: no implicit conversion of String into Integer`.

`Api::EvaluationsController#index` (`actionagent/app/controllers/action_agent/api/evaluations_controller.rb:28-30`) serializes the latest run of all 50 listed evaluations, and `serialize_run` (`:133-145`) called `run.average_score`. So one comparison run with a cohort that had no generations permanently 500'd `GET <mount>/api/evaluations` — the entire Evaluations view and every agent page's Evals tab became an unrecoverable "Failed to load evaluations" error.

A second, quieter bug in the same line: for a comparison run, each criterion is a **cohort map** (`model => stats`), so `s["score"]` returned `nil` and every comparison run reported no headline average at all.

## What changed

**`actionagent/app/models/action_agent/evaluation_run.rb`** — `average_score` now:
- rejects `"_"`-prefixed metadata keys (`_missing_models`, `_verdict`),
- considers only `Hash` values,
- reads `"score"` when the criterion is scored directly, and otherwise detects a comparison cohort map (values that are themselves Hashes carrying a numeric `"score"`) and averages the per-model scores, so a comparison run gets a real headline average instead of `nil`,
- compacts and averages what remains; `nil` when nothing is scorable.

Skipped criteria (`{"skipped" => true, "reason" => ...}`) still contribute nothing, including a cohort whose models were all skipped.

**`actionagent/app/controllers/action_agent/api/evaluations_controller.rb`** — defence in depth, as the issue suggests: `serialize_run` now goes through `safe_average_score`, which logs and returns `nil` if a run's payload can't be averaged. One malformed run degrades its own headline number instead of 500-ing the whole index.

Scope: engine copy only. The app twin (`app/models/evaluation_run.rb`) is covered by a separate PR in this wave.

## How this was verified

New regression tests in `actionagent/test/evaluation_run_test.rb` (8 model tests + 1 request test through the mounted engine), covering: `_missing_models` must not raise and must be excluded; underscore metadata alone averages to `nil`; a cohort map averages per-model scores; cohort maps mixed with `_missing_models` and `_verdict`; an all-skipped cohort; and `GET /activeagents/api/evaluations` returning 200 for an evaluation whose latest run carries `_missing_models`.

**Proven to fail without the fix** — `git stash push -- actionagent/app/models/action_agent/evaluation_run.rb`, then:

```
ActionAgentEvaluationRunTest#test__missing_models_does_not_raise_and_is_excluded_from_the_average:
TypeError: no implicit conversion of String into Integer
    actionagent/app/models/action_agent/evaluation_run.rb:14:in `block in average_score'
    actionagent/app/models/action_agent/evaluation_run.rb:14:in `map'
    actionagent/app/models/action_agent/evaluation_run.rb:14:in `average_score'

9 runs, 5 assertions, 0 failures, 5 errors, 0 skips
```

**Passing with the fix restored** (`git stash pop`):

```
9 runs, 12 assertions, 0 failures, 0 errors, 0 skips
```

**Full suite** (`BUNDLE_GEMFILE=gemfiles/rails8.gemfile CI=true RAILS_ENV=test bin/test`):

```
Finished in 41.231844s, 35.8218 runs/s, 94.2718 assertions/s.
1477 runs, 3887 assertions, 0 failures, 0 errors, 22 skips
```

Baseline on `main` is 1468 runs / 0 failures / 0 errors / 22 skips; 1477 = baseline + the 9 new tests, still green.

Fixes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157vWB31zDjEX1mCCMDE4W3

---
_Generated by [Claude Code](https://claude.ai/code/session_0157vWB31zDjEX1mCCMDE4W3)_