### PR TITLE
Correct the average_score comments flagged in review of #399

### DIFF
--- a/actionagent/app/controllers/action_agent/api/evaluations_controller.rb
+++ b/actionagent/app/controllers/action_agent/api/evaluations_controller.rb
@@ -145,7 +145,7 @@ module ActionAgent
       end
 
       # index serializes the latest run of every listed evaluation, so an
-      # unaveragable scores payload used to 500 the entire Evaluations page
+      # unaverageable scores payload used to 500 the entire Evaluations page
       # instead of degrading that one run's headline number.
       def safe_average_score(run)
         run.average_score

--- a/actionagent/app/models/action_agent/evaluation_run.rb
+++ b/actionagent/app/models/action_agent/evaluation_run.rb
@@ -2,7 +2,10 @@
 
 module ActionAgent
   # One execution of an Evaluation over a sample of the agent's generations.
-  # scores: { criterion_key => { "score", "min", "max", "passed", "total" } }
+  # scores: { criterion_key => { "score", "min", "max", "passed", "total" } },
+  # except on a comparison run, where each criterion is a cohort map of
+  # model => stats and "_"-prefixed metadata keys sit alongside the criteria.
+  # See #average_score, which is what has to tolerate both shapes.
   class EvaluationRun < ApplicationRecord
     belongs_to :evaluation
 

--- a/actionagent/test/evaluation_run_test.rb
+++ b/actionagent/test/evaluation_run_test.rb
@@ -96,7 +96,7 @@ class ActionAgentEvaluationRunTest < ActiveSupport::TestCase
 end
 
 # The Evaluations index serializes the latest run of every listed evaluation,
-# so a single unaveragable run used to take the whole page down.
+# so a single unaverageable run used to take the whole page down.
 class ActionAgentEvaluationsIndexTest < ActionDispatch::IntegrationTest
   def setup
     ActionAgent::Agent.delete_all


### PR DESCRIPTION
## Why this is a separate PR

Copilot left three comment-level nits on #399. By the time they were addressed, #399 had already merged, and a merged pull request can't carry follow-up work — so they land here instead. All three are still present on `main` (`8efbb55`), verified before opening this.

Comment-only: no behavior change, no logic touched.

## What changed

**1 & 3 — spelling, in two places.** `unaveragable` → `unaverageable`, in `actionagent/app/controllers/action_agent/api/evaluations_controller.rb:148` and `actionagent/test/evaluation_run_test.rb:99`. The silent `e` is retained after a soft *g* (`manageable`, `changeable`); without it the word reads with a hard *g*.

**2 — the class-level doc comment was still asserting the shape that caused the bug.** `actionagent/app/models/action_agent/evaluation_run.rb` documented `scores` as uniformly `{ criterion_key => stats }`, which is exactly the assumption `#average_score` had to be fixed to stop making. #399 added a detailed note above the method but left the class comment contradicting it:

```ruby
# One execution of an Evaluation over a sample of the agent's generations.
# scores: { criterion_key => { "score", "min", "max", "passed", "total" } },
# except on a comparison run, where each criterion is a cohort map of
# model => stats and "_"-prefixed metadata keys sit alongside the criteria.
# See #average_score, which is what has to tolerate both shapes.
```

Worth doing rather than waving through: the stale comment is what would set the next reader up to reintroduce the crash.

## Verification

- `actionagent/test/evaluation_run_test.rb` — 9 runs, 12 assertions, 0 failures, 0 errors.
- `bin/rubocop --force-exclusion <the three files>` — 3 files inspected, no offenses.

## Related

- Follows #399 (merged), which fixed the underlying `TypeError`.
- Original issue: #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157vWB31zDjEX1mCCMDE4W3

---
_Generated by [Claude Code](https://claude.ai/code/session_0157vWB31zDjEX1mCCMDE4W3)_