### PR TITLE
fix(actionagent): derive encryption keys before Rails configures the encryptor

### DIFF
--- a/actionagent/lib/action_agent/engine.rb
+++ b/actionagent/lib/action_agent/engine.rb
@@ -139,13 +139,19 @@ module ActionAgent
     # skipped it too. Without keys, every credential write and every
     # authenticated MCP request raised Errors::Configuration as an HTML 500.
     #
-    # Rails reads config.active_record.encryption in after_initialize, so an
-    # initializer can still supply keys. When the host set none — neither
-    # here nor in credentials — derive stable ones from secret_key_base,
-    # overridable through the ACTIVE_RECORD_ENCRYPTION_* variables, exactly
-    # as the activeagents.ai platform does. Host-provided keys are never
+    # Rails seeds ActiveRecord::Encryption from credentials and
+    # config.active_record.encryption in its own
+    # "active_record_encryption.configuration" initializer. Keys derived
+    # after that one land in config but never reach the encryptor, so the
+    # config reads back correct while every credential write raises
+    # Errors::Configuration — which is what a host that skipped
+    # db:encryption:init actually hits. Naming it in `before:` is what puts
+    # the derivation ahead of it. When the host set no keys — neither here
+    # nor in credentials — derive stable ones from secret_key_base, overridable
+    # through the ACTIVE_RECORD_ENCRYPTION_* variables, exactly as the
+    # activeagents.ai platform does. Host-provided keys are never
     # overridden, and the derivation is stable as long as secret_key_base is.
-    initializer "action_agent.active_record_encryption", after: :load_config_initializers do |app|
+    initializer "action_agent.active_record_encryption", before: "active_record_encryption.configuration" do |app|
       next unless ActionAgent.encrypt_credentials
       next unless app.config.respond_to?(:active_record)
 

--- a/actionagent/test/credentials_test.rb
+++ b/actionagent/test/credentials_test.rb
@@ -22,6 +22,17 @@ class CredentialsTest < ActionDispatch::IntegrationTest
     assert ActiveRecord::Encryption.config.primary_key.present?
   end
 
+  test "a credential round-trips through encryption" do
+    key = ActionAgent::ProviderKey.create!(provider: "openrouter", credential: "sk-or-v1-roundtrip")
+
+    assert_equal "sk-or-v1-roundtrip", key.reload.generation_options[:access_token]
+    assert_not_equal "sk-or-v1-roundtrip",
+      ActionAgent::ProviderKey.connection.select_value(
+        "SELECT credential FROM #{ActionAgent::ProviderKey.table_name} WHERE id = #{key.id}"
+      ),
+      "the stored column must not hold the plain credential"
+  end
+
   test "an API key can be created and authenticates the MCP facade" do
     post "/activeagents/api/api_keys", params: { name: "mcp-probe" }
 

--- a/actionagent/test/credentials_test.rb
+++ b/actionagent/test/credentials_test.rb
@@ -26,10 +26,16 @@ class CredentialsTest < ActionDispatch::IntegrationTest
     key = ActionAgent::ProviderKey.create!(provider: "openrouter", credential: "sk-or-v1-roundtrip")
 
     assert_equal "sk-or-v1-roundtrip", key.reload.generation_options[:access_token]
-    assert_not_equal "sk-or-v1-roundtrip",
-      ActionAgent::ProviderKey.connection.select_value(
-        "SELECT credential FROM #{ActionAgent::ProviderKey.table_name} WHERE id = #{key.id}"
-      ),
+    # Read the column through the connection, not the model: an AR read
+    # decrypts the attribute, so only the raw row shows whether the stored
+    # value is ciphertext.
+    connection = ActionAgent::ProviderKey.connection
+    stored = connection.select_value(
+      "SELECT credential FROM #{connection.quote_table_name(ActionAgent::ProviderKey.table_name)} " \
+      "WHERE id = #{connection.quote(key.id)}"
+    )
+
+    assert_not_equal "sk-or-v1-roundtrip", stored,
       "the stored column must not hold the plain credential"
   end
 


### PR DESCRIPTION
A host that skipped `rails db:encryption:init` — which the engine's own comment notes is most of them — could not store a provider credential at all. The derivation of encryption keys from `secret_key_base` ran *after* Rails' own `active_record_encryption.configuration` initializer, so the derived keys landed in `config.active_record.encryption`, which reads back correct, while `ActiveRecord::Encryption.config` stayed empty and every write raised `Errors::Configuration`.

In the dashboard that surfaced twice, and both looked like frontend bugs: the Settings → API Keys tab silently failed to render (its `/api/provider_keys` fetch never completed), and saving a provider key errored.

Naming Rails' initializer in `before:` puts the derivation ahead of it.

## Verification

A/B against a real host with no encryption credentials (`credentials.dig(:active_record_encryption, :primary_key)` absent), same app and command, only this line differing:

- `after: :load_config_initializers` → `Missing Active Record encryption credential: active_record_encryption.primary_key`
- `before: "active_record_encryption.configuration"` → the encryptor has its key; the provider key stores, encrypts, and decrypts back to the exact value

Confirmed in the dashboard afterwards: the API Keys tab renders and OpenRouter shows as configured.

## Tests

Adds a round-trip test asserting a credential decrypts to what was written and that the stored column does not hold the plaintext. I also tried asserting initializer *positions*, but that encodes a wrong theory — engine initializers always run after the host's railties, so the ordinal never changes; `before:` affects resolution, not the index. Dropped it rather than ship a test that would mislead the next reader.
