### PR TITLE
Release activeagent 1.4.0 and actionagent 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-09-09
+
+Releases `activeagent` 1.4.0 and `actionagent` 1.3.0 from one tag.
+
 ### Added
 
 - **`ActiveAgent::Evals`, the evaluation core, in the framework.** Pasted-list
@@ -115,6 +119,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model-based routing unchanged. (#373)
 
 ### Fixed
+
+- **A run report is readable in the dashboard.** The report was framed at a
+  fixed viewport height, so everything past the first screen — including
+  every fix item — sat behind a nested scrollbar. The frame is sized to the
+  report's own content, and a fix action targets the top window so it
+  navigates the dashboard instead of loading it into the frame. (#410, #411)
+
+- **Provider credentials store on a host that skipped `db:encryption:init`.**
+  Encryption keys derived from `secret_key_base` were installed after Rails
+  had already configured `ActiveRecord::Encryption`, so the config read back
+  correct while every credential write raised `Errors::Configuration` — in
+  the dashboard, the Settings API Keys tab failed to render and provider
+  keys failed to save. (#412)
 
 - **`service: "RubyLLM"` loads when the ruby_llm railtie has run.** The
   ruby_llm gem registers `RubyLLM` as an inflector acronym in Rails apps,

--- a/actionagent/actionagent.gemspec
+++ b/actionagent/actionagent.gemspec
@@ -41,13 +41,16 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true"
   }
 
-  # The dashboard executes agents through the framework. The floor is 1.2
-  # deliberately: every earlier release still contains the in-gem dashboard
-  # this engine replaces, and lacks ActiveAgent::Telemetry::ToolOrigin, which
-  # the Tools view calls. Resolving against one of those would load two
-  # dashboards and leave ActiveAgent::Dashboard defined, so the compatibility
-  # shim would never fire.
-  spec.add_dependency "activeagent", ">= 1.2", "< 2"
+  # The dashboard executes agents through the framework. The floor is 1.4
+  # because ScenarioEvaluationRunner resolves ActiveAgent::Evals, which the
+  # framework only gained in 1.4.0 — an older resolution installs cleanly and
+  # then raises NameError on the first scenario run. Earlier releases are
+  # unusable here for two further reasons: each still contains the in-gem
+  # dashboard this engine replaces, so resolving against one would load two
+  # dashboards and leave ActiveAgent::Dashboard defined (the compatibility
+  # shim would never fire), and none has
+  # ActiveAgent::Telemetry::ToolOrigin, which the Tools view calls.
+  spec.add_dependency "activeagent", ">= 1.4", "< 2"
 
   # It is a Rails engine, so it needs railties — as does the framework, which
   # declares it too. Active Record is the one that matters here: `activeagent`

--- a/actionagent/lib/action_agent/version.rb
+++ b/actionagent/lib/action_agent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActionAgent
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Bumps both gems for the evaluation and dashboard work merged since v1.3.1 (53 commits). One `v1.4.0` tag builds and publishes both, as `release.yml` does today.

| gem | from | to | why |
|---|---|---|---|
| `activeagent` | 1.3.1 | **1.4.0** | new public `ActiveAgent::Evals` module — additive, so minor |
| `actionagent` | 1.2.2 | **1.3.0** | scenario suites, the APM Metrics view, the run report, host MCP catalog registration |

The existing `[Unreleased]` section becomes `[1.4.0]`, with a fresh empty `[Unreleased]` above it, plus entries for the two dashboard fixes that landed after it was written (#410/#411 report readability, #412 credential encryption).

Verified both gemspecs build at the new versions.

## Before tagging

**#412 should merge first** — without it, a host that skipped `rails db:encryption:init` cannot store a provider credential at all, and the Settings API Keys tab fails to render. That is a poor first impression for a release whose headline is the dashboard.

Publishing still needs a maintainer: `release.yml` requires a trusted publisher on rubygems.org for both gem names, and until that exists the push step fails and the gem has to go up by hand with an OTP.
