### PR TITLE
Execute host MCP tools in dashboard runs and evaluations

### DIFF
--- a/actionagent/README.md
+++ b/actionagent/README.md
@@ -80,6 +80,61 @@ dashboard, the resolver above returned `nil`.
 See [the self-hosted observability guide](https://docs.activeagents.ai/framework/self-hosted-observability)
 for the full list.
 
+## Execute host MCP tools
+
+Register a Streamable HTTP endpoint, then enable it and select tools on the
+dashboard agent:
+
+```ruby
+ActionAgent.configure do |config|
+  config.mcp_catalog = [
+    {
+      key: "operations",
+      name: "Host operations",
+      transport: "http",
+      url: ENV.fetch("OPERATIONS_MCP_URL"),
+      tool_hints: [ "healthcheck" ]
+    }
+  ]
+end
+
+agent.update!(mcp_servers: [ "operations" ], tools: [ "healthcheck" ])
+agent.test_execute("Check database health")
+```
+
+The engine reads `tools/list` for the selected tools' descriptions and JSON
+schemas and calls `tools/call` on the same connection session. Catalog hints
+help identify a server; they do not substitute for its live tool definitions.
+Only tools selected in `agent.tools` are offered to the model. A catalog entry
+alone does not enable its server.
+
+An agent's `mcp_servers` accepts bare catalog keys, builder hashes such as
+`[{ key: "operations", url: "https://host.example/mcp", transport: "http" }]`,
+or legacy name-keyed hashes. Inline connection settings override the catalog.
+Use `mcp__operations__healthcheck` to select a particular server when multiple
+enabled servers claim the same bare tool name. The namespace is removed from
+the name sent to the MCP server.
+
+Enabled MCP tools take precedence over built-in tools, including builder
+category names. Otherwise, supported categories such as `code` and `memory`
+still expand to their built-in functions, and exact built-in function names
+such as `calculate` are accepted. A declared tool with no executable binding
+fails the run before provider generation, with the tool or server to fix.
+MCP tool failures appear in run events, traces, and scenario results; they
+never fall back to a similarly named toolbox function.
+
+Observed agents can run and participate in scenario evaluations using their
+stored instructions, model, and enabled servers. The normal owner, quota,
+provider-credential, and dashboard execution settings still apply. Evaluations
+use this native execution path without a host-specific evaluation runner.
+
+Supported transports are `http`, `streamable_http`, and `streamable-http`,
+over absolute HTTP or HTTPS URLs. The client supports JSON and SSE responses,
+paginated discovery, and optional MCP sessions. `stdio` commands and legacy
+SSE transports are not launched by dashboard execution; configure their
+Streamable HTTP endpoint instead. The existing Playwright toolbox client
+keeps its `PLAYWRIGHT_MCP_URL` default.
+
 ## Assets
 
 The dashboard's JavaScript and CSS ship prebuilt in the gem, under

--- a/actionagent/app/controllers/action_agent/api/agents_controller.rb
+++ b/actionagent/app/controllers/action_agent/api/agents_controller.rb
@@ -20,7 +20,6 @@ module ActionAgent
       before_action :set_agent, only: [ :show, :update, :destroy, :versions, :runs, :execute, :test, :restore, :duplicate, :export, :analytics ]
       before_action :require_execution_enabled!, only: [ :execute, :test ]
       before_action :require_owner!, only: [ :execute, :test ]
-      before_action :require_executable_agent!, only: [ :execute, :test ]
       before_action :enforce_execution_quota!, only: [ :execute, :test ]
 
       # GET /api/agents
@@ -312,19 +311,6 @@ module ActionAgent
       end
 
       private
-
-      # Observed agents were discovered from reported telemetry; the platform
-      # has no configuration to run them with (a placeholder model, no
-      # instructions), so executing one only manufactured a failed run that
-      # was then blended into the clean scorecard its telemetry had built.
-      # Duplicating an observed agent yields a draft that can be run.
-      def require_executable_agent!
-        return unless @agent.observed?
-
-        render json: {
-          error: "Observed agents are read-only — duplicate this agent to create an executable copy"
-        }, status: :unprocessable_entity
-      end
 
       def list_sort(requested)
         LIST_SORTS.key?(requested.to_s) ? requested.to_s : DEFAULT_LIST_SORT

--- a/actionagent/app/controllers/action_agent/api/evaluations_controller.rb
+++ b/actionagent/app/controllers/action_agent/api/evaluations_controller.rb
@@ -13,10 +13,10 @@ module ActionAgent
       before_action :require_owner!
       # A scenario suite replays its prompts through the provider, so creating
       # one that runs, or running one, executes the agent and is gated the way
-      # AgentsController#execute is: the dashboard's execution switch, no
-      # observed (read-only) agents, and the owner's execution quota. Each
+      # AgentsController#execute is: the dashboard's execution switch and
+      # the owner's execution quota. Each
       # replay then counts as one execution (ScenarioEvaluationRunner#replay).
-      before_action :require_execution_enabled!, :require_executable_scenario_agent!, :enforce_execution_quota!,
+      before_action :require_execution_enabled!, :enforce_execution_quota!,
                     only: [ :create, :run ], if: :replays_scenarios?
 
       # Default criteria used when none are supplied — all rule-based, so a
@@ -235,17 +235,6 @@ module ActionAgent
         when "create" then run_requested? && scenario_attributes.any?
         else false
         end
-      end
-
-      # The refusal AgentsController gives an observed agent: it was
-      # discovered from telemetry and has nothing to execute.
-      def require_executable_scenario_agent!
-        agent = action_name == "create" ? requested_agent : current_evaluation.agent
-        return unless agent.observed?
-
-        render json: {
-          error: "Observed agents are read-only — duplicate this agent to create an executable copy"
-        }, status: :unprocessable_entity
       end
 
       def evaluation_params

--- a/actionagent/app/models/action_agent/agent.rb
+++ b/actionagent/app/models/action_agent/agent.rb
@@ -30,8 +30,8 @@ module ActionAgent
 
     # Status enum
     # `observed` agents were discovered from reported telemetry rather than
-    # authored here. They can't be executed by the platform — we can't push
-    # instructions into someone else's app — so they're read-only until forked.
+    # authored here. Their status records that origin; execution uses the
+    # same provider credentials and executable tool bindings as authored agents.
     enum :status, { draft: 0, active: 1, archived: 2, observed: 3 }
 
     scope :observed_agents, -> { where(status: :observed) }

--- a/actionagent/app/services/action_agent/agent_execution_service.rb
+++ b/actionagent/app/services/action_agent/agent_execution_service.rb
@@ -20,6 +20,7 @@ module ActionAgent
     # Raised when the requested provider has no usable credentials. The run is
     # marked failed with this message — never silently degraded to mock output.
     class ProviderNotConfiguredError < StandardError; end
+    class ToolNotConfiguredError < StandardError; end
 
     SERVICE_NAME = "activeagents-platform"
 
@@ -60,7 +61,6 @@ module ActionAgent
 
     def call
       root_span = @root_span = build_root_span
-      record_prompt_span(root_span)
       llm_span = root_span.add_span(
         "llm.generate",
         span_type: :llm,
@@ -73,6 +73,11 @@ module ActionAgent
       emit_event(eid: llm_eid, kind: "llm", label: "#{provider}/#{model} generating", status: "started")
 
       begin
+        # Resolve the entire declared roster before a provider can answer.
+        # Missing host tools must fail the run, even if the model would never
+        # have requested them (or this is an offline mock replay).
+        resolved_tool_schemas
+        record_prompt_span(root_span)
         response = generate!
         usage = response.usage
         input = usage&.input_tokens.to_i
@@ -184,20 +189,27 @@ module ActionAgent
       @composed_instructions ||= @agent_record.composed_instructions_for(action_name)
     end
 
-    # Routes a provider tool call to its implementation: memory tools bind to
-    # the agent record's AgentMemory (the solid_agent HasMemory contract);
-    # everything else is stateless and lives in AgentToolbox.
+    # Enabled MCP servers take precedence over the engine's implementations.
+    # The binding and schema come from the same per-run discovery, so dispatch
+    # uses the server whose contract was actually offered to the model.
     #
     # Each call is wrapped in a live :tool span (real start/end around the
     # execution) and recorded in @tool_invocations so tool names, arguments
     # and durations reach Traces and the persisted conversation.
     def execute_tool(name, **kwargs)
+      binding = resolved_tool_bindings.fetch(name.to_s) do
+        raise ToolNotConfiguredError, "Tool '#{name}' is not enabled for agent '#{@agent_record.name}'"
+      end
+      mcp = binding[:mcp]
       # Record the absolute URL browse_page will actually fetch, not the bare
       # path the model passed — spans/events/persisted args stay unambiguous.
-      kwargs[:url] = AgentToolbox.resolve_browse_url(kwargs[:url]) if name.to_s == "browse_page" && kwargs[:url]
+      kwargs[:url] = AgentToolbox.resolve_browse_url(kwargs[:url]) if !mcp && name.to_s == "browse_page" && kwargs[:url]
 
       span = @root_span&.add_span("tool.#{name}", span_type: :tool)
       span&.set_attribute("tool.name", name.to_s)
+      span&.set_attribute("tool.mcp_server", mcp[:server]) if mcp
+      span&.set_attribute("tool.base_name", mcp[:name]) if mcp
+      span&.set_attribute("tool.origin", "mcp") if mcp
       # tool.input.args is the key the Traces UI and TraceInteractionSerializer
       # read — the call's in: side.
       span&.set_attribute("tool.input.args", kwargs.to_json.byteslice(0, 500).to_s.scrub) if kwargs.present?
@@ -209,31 +221,10 @@ module ActionAgent
       emit_event(eid: event_id, kind: event_kind, label: event_label, status: "started", detail: kwargs.to_json)
 
       result = begin
-        case name.to_s
-        when "save_memory"
-          entry = agent_memory.remember(
-            kwargs[:content].to_s,
-            source_agent: agent_class_name,
-            category: kwargs[:category]
-          )
-          { saved: true, id: entry.id, content: entry.content }
-        when "recall_memory"
-          entries = agent_memory.recall(limit: kwargs[:limit], category: kwargs[:category])
-          {
-            count: entries.size,
-            entries: entries.map do |entry|
-              {
-                content: entry.content,
-                category: entry.category,
-                source_agent: entry.source_agent,
-                created_at: entry.created_at&.iso8601
-              }.compact
-            end
-          }
-        when "call_agent"
-          call_agent(slug: kwargs[:slug], message: kwargs[:message])
+        if mcp
+          mcp[:client].call_tool(mcp[:name], kwargs)
         else
-          AgentToolbox.call(name, **kwargs)
+          execute_builtin_tool(name, **kwargs)
         end
       rescue StandardError => e
         Rails.logger.warn("[AgentExecutionService] Tool #{name} failed: #{e.class} - #{e.message}")
@@ -241,7 +232,8 @@ module ActionAgent
       end
 
       duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
-      errored = result.respond_to?(:key?) && (result.key?(:error) || result.key?("error"))
+      errored = result.respond_to?(:key?) &&
+        (result.key?(:error) || result.key?("error") || result[:is_error] == true || result["is_error"] == true)
       span&.set_attribute("tool.error", true) if errored
       # Record the readable side of the result (most tools wrap one long text
       # field); byteslicing whole-JSON breaks it mid-string and the UI can't
@@ -257,7 +249,7 @@ module ActionAgent
       emit_event(
         eid: event_id, kind: event_kind, label: event_label,
         status: errored ? "error" : "done", duration_ms: duration_ms,
-        detail: errored ? (result[:error] || result["error"]).to_s : event_result_preview(result)
+        detail: errored ? (result[:error] || result["error"] || result_text).to_s : event_result_preview(result)
       )
       @tool_invocations << {
         name: name.to_s,
@@ -269,7 +261,76 @@ module ActionAgent
       result
     end
 
+    # Provider-independent roster, also useful to callers inspecting a run's
+    # executable contract. Categories retain their builder expansion; exact
+    # function names support agents reconstructed from telemetry.
+    def resolved_tool_schemas
+      resolved_tool_bindings.values.map { |binding| binding[:definition] }
+    end
+
     private
+
+    def resolved_tool_bindings
+      @resolved_tool_bindings ||= begin
+        builtin = AgentToolbox::DEFINITIONS.values.flatten.index_by { |definition| definition[:name].to_s }
+        resolver = MCPToolBinding.new(@agent_record)
+        unresolved = []
+        bindings = Array(@agent_record.tools).each_with_object({}) do |declared, entries|
+          name = declared.to_s
+          if (mcp = resolver.resolve(name))
+            entries[name] = { definition: mcp[:definition], mcp: mcp }
+            next
+          end
+
+          category = AgentToolbox::DEFINITIONS[name]
+          names = category ? category.map { |definition| definition[:name].to_s } : [ name ]
+          names.each do |tool_name|
+            if (mcp = resolver.resolve(tool_name))
+              entries[tool_name] = { definition: mcp[:definition], mcp: mcp }
+            elsif (definition = builtin[tool_name])
+              entries[tool_name] = { definition: definition }
+            else
+              unresolved << tool_name
+            end
+          end
+        end
+        if unresolved.any?
+          raise ToolNotConfiguredError,
+            "Agent '#{@agent_record.name}' has tools with no executable binding: #{unresolved.join(', ')}. " \
+            "Configure an enabled MCP server with an HTTP URL that lists these tools, or remove them from the agent."
+        end
+        bindings
+      end
+    end
+
+    def execute_builtin_tool(name, **kwargs)
+      case name.to_s
+      when "save_memory"
+        entry = agent_memory.remember(
+          kwargs[:content].to_s,
+          source_agent: agent_class_name,
+          category: kwargs[:category]
+        )
+        { saved: true, id: entry.id, content: entry.content }
+      when "recall_memory"
+        entries = agent_memory.recall(limit: kwargs[:limit], category: kwargs[:category])
+        {
+          count: entries.size,
+          entries: entries.map do |entry|
+            {
+              content: entry.content,
+              category: entry.category,
+              source_agent: entry.source_agent,
+              created_at: entry.created_at&.iso8601
+            }.compact
+          end
+        }
+      when "call_agent"
+        call_agent(slug: kwargs[:slug], message: kwargs[:message])
+      else
+        AgentToolbox.call(name, **kwargs)
+      end
+    end
 
     # Maximum agent-to-agent delegation depth for the call_agent tool. A
     # thread-local counter guards it because the sub-agent runs synchronously
@@ -383,14 +444,11 @@ module ActionAgent
           generate_with effective_provider, model: provider_model, **model_options
         end
 
-        # Expose the agent's server-executable tools as public methods so the
-        # gem's tools_function can route provider tool calls to them. The
-        # service routes each call to AgentToolbox or, for memory tools, to
-        # the run's AgentMemory.
-        tool_definitions.each do |definition|
-          define_method(definition[:name]) do |**kwargs|
-            service.execute_tool(definition[:name], **kwargs)
-          end
+        # Route through the selected roster directly. MCP names such as
+        # "prompt" or "ask" are valid tools, but defining them as methods
+        # would overwrite framework methods or the action below.
+        define_method(:tools_function) do
+          proc { |name, **kwargs| service.execute_tool(name, **kwargs) }
         end
 
         # One method per invokable action (the default plus each named action
@@ -417,9 +475,10 @@ module ActionAgent
     # server-side implementations (none for mock runs — the mock provider
     # doesn't do tool calling).
     def tool_schemas
+      definitions = resolved_tool_schemas
       return [] if provider == :mock
 
-      AgentToolbox.definitions_for(@agent_record.tools)
+      definitions
     end
 
     # Persists the tool interaction stream to the solid_agent conversation

--- a/actionagent/app/services/action_agent/agent_toolbox.rb
+++ b/actionagent/app/services/action_agent/agent_toolbox.rb
@@ -11,9 +11,8 @@ module ActionAgent
   # tool-call roundtrips that show up as :tool spans in Traces, tool messages
   # in Interactions, and tool counts in Metrics.
   #
-  # Only tools with a safe server-side implementation are mapped; anything
-  # else an agent enables (terminal, playwright, ...) is ignored for platform
-  # execution.
+  # Only tools with server-side implementations are mapped here. Execution
+  # also binds host MCP tools, and rejects declarations neither can execute.
   class AgentToolbox
     FETCH_LIMIT_BYTES = 50_000
     FETCH_TIMEOUT_SECONDS = 5

--- a/actionagent/app/services/action_agent/evaluation_tool_resolver.rb
+++ b/actionagent/app/services/action_agent/evaluation_tool_resolver.rb
@@ -72,6 +72,18 @@ module ActionAgent
       nil
     end
 
+    # The agent's enabled servers in a common shape, shared with execution.
+    # This deliberately does not add available-but-disabled catalog servers.
+    def configured_servers
+      configured_entries.filter_map do |entry|
+        key = normalize(entry_key(entry))
+        next unless key
+
+        attributes = entry.respond_to?(:key?) ? entry.to_h.symbolize_keys : {}
+        attributes.merge(key: key)
+      end
+    end
+
     private
 
     # The catalog's name when it has one; otherwise the name the agent's

--- a/actionagent/app/services/action_agent/mcp_client.rb
+++ b/actionagent/app/services/action_agent/mcp_client.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "resolv"
+
+module ActionAgent
+  # A tool client for MCP's Streamable HTTP transport. A server may return
+  # JSON or SSE, and may use a session id or operate without sessions.
+  class MCPClient
+    PROTOCOL_VERSION = "2025-06-18"
+    SUPPORTED_PROTOCOL_VERSIONS = [ PROTOCOL_VERSION, "2025-03-26" ].freeze
+    OPEN_TIMEOUT_SECONDS = 5
+    READ_TIMEOUT_SECONDS = 60
+
+    class Error < StandardError; end
+    class SessionExpired < Error; end
+
+    def initialize(url:, transport: "http")
+      transport = "http" if transport.nil? || transport.to_s.empty?
+      unless %w[http streamable_http streamable-http].include?(transport.to_s.downcase)
+        raise Error, "Unsupported MCP transport #{transport.inspect}; use Streamable HTTP (http). stdio and legacy SSE are not supported"
+      end
+
+      @uri = URI.parse(url.to_s)
+      unless @uri.is_a?(URI::HTTP) && @uri.host
+        raise Error, "MCP server URL must be an absolute HTTP or HTTPS URL"
+      end
+      @session_mutex = Mutex.new
+      @id_mutex = Mutex.new
+    rescue URI::InvalidURIError
+      raise Error, "MCP server URL must be an absolute HTTP or HTTPS URL"
+    end
+
+    # Return the server's tool definitions, preserving inputSchema and any
+    # optional metadata. Follow cursors because tools/list can be paginated.
+    def list_tools
+      tools = []
+      cursors = []
+      cursor = nil
+      loop do
+        result = request("tools/list", cursor ? { cursor: cursor } : {})
+        unless result["tools"].is_a?(Array) && result["tools"].all? { |tool| tool.is_a?(Hash) }
+          raise Error, "MCP tools/list response must contain a tools array"
+        end
+        tools.concat(result["tools"])
+        cursor = result["nextCursor"]
+        break if cursor.nil?
+        raise Error, "MCP tools/list returned an invalid or repeated cursor" unless cursor.is_a?(String) && !cursors.include?(cursor)
+
+        cursors << cursor
+      end
+      tools
+    end
+
+    # Keep the browser client's existing result contract. Structured output
+    # is retained too, including servers that return no text blocks.
+    def call_tool(name, arguments = {})
+      result = request("tools/call", { name: name, arguments: arguments })
+      text = Array(result["content"]).filter_map { |block| block["text"] if block.is_a?(Hash) }.join("\n")
+      output = { text: text, is_error: result["isError"] == true }
+      if result.key?("structuredContent")
+        output[:structured_content] = result["structuredContent"]
+        output[:text] = JSON.generate(result["structuredContent"]) if text.empty?
+      end
+      output
+    end
+
+    private
+
+    def request(method, params)
+      retries = 0
+      begin
+        ensure_session!
+        body, = post_raw(
+          { jsonrpc: "2.0", id: next_id, method: method, params: params },
+          session: @session_id, protocol_version: @protocol_version
+        )
+        result_from(body)
+      rescue SessionExpired
+        reset_session!
+        raise if retries >= 1
+
+        retries += 1
+        retry
+      rescue SystemCallError, IOError, Timeout::Error, SocketError, OpenSSL::SSL::SSLError => e
+        reset_session!
+        raise Error, "MCP server connection failed (#{e.class})"
+      end
+    end
+
+    def ensure_session!
+      @session_mutex.synchronize do
+        return if @initialized
+
+        body, response = post_raw(
+          { jsonrpc: "2.0", id: next_id, method: "initialize",
+            params: { protocolVersion: PROTOCOL_VERSION, capabilities: {},
+                      clientInfo: { name: "activeagents", version: "1.0" } } }
+        )
+        protocol_version = result_from(body)["protocolVersion"]
+        unless SUPPORTED_PROTOCOL_VERSIONS.include?(protocol_version)
+          raise Error, "Unsupported MCP protocol version #{protocol_version.inspect}"
+        end
+        session_id = response["mcp-session-id"]
+        post_raw(
+          { jsonrpc: "2.0", method: "notifications/initialized" },
+          session: session_id, protocol_version: protocol_version
+        )
+        @session_id = session_id
+        @protocol_version = protocol_version
+        @initialized = true
+      end
+    end
+
+    def reset_session!
+      @session_mutex.synchronize do
+        @initialized = false
+        @session_id = nil
+        @protocol_version = nil
+      end
+    end
+
+    def result_from(body)
+      if body["error"]
+        error = body["error"]
+        raise Error, "MCP error #{error['code']}: #{error['message']}"
+      end
+      raise Error, "MCP response is missing a result" unless body["result"].is_a?(Hash)
+
+      body["result"]
+    end
+
+    def post_raw(payload, session: nil, protocol_version: nil)
+      # Provider SDK streaming enumerators run in fibers. Keep Net::HTTP's
+      # blocking reads on a dedicated thread, as the browser client did.
+      Thread.new do
+        Thread.current.report_on_exception = false
+        blocking_post_raw(payload, session: session, protocol_version: protocol_version)
+      end.value
+    end
+
+    def blocking_post_raw(payload, session:, protocol_version:)
+      http = Net::HTTP.new(@uri.host, @uri.port)
+      http.use_ssl = @uri.scheme == "https"
+      # Container->host bridge hostnames can publish an unreachable IPv6
+      # address. Pin to IPv4 where available, retaining Host and TLS SNI.
+      http.ipaddr = ipv4_address if ipv4_address
+      http.open_timeout = OPEN_TIMEOUT_SECONDS
+      http.read_timeout = READ_TIMEOUT_SECONDS
+      request = Net::HTTP::Post.new(@uri.request_uri)
+      request["Content-Type"] = "application/json"
+      request["Accept"] = "application/json, text/event-stream"
+      request["Mcp-Session-Id"] = session if session
+      request["MCP-Protocol-Version"] = protocol_version if protocol_version
+      request.body = JSON.generate(payload)
+
+      http.request(request) do |response|
+        raise SessionExpired, "MCP session expired" if response.code == "404" && session
+        unless response.code.to_i.between?(200, 299)
+          raise Error, "MCP server returned HTTP #{response.code}"
+        end
+
+        return [ {}, response ] unless payload.key?(:id)
+
+        return [ parse_body(response, payload[:id]), response ]
+      end
+    end
+
+    def parse_body(response, request_id)
+      if response["Content-Type"].to_s.include?("text/event-stream")
+        # SSE data may span multiple lines and network chunks. Stop when
+        # our response arrives; the server need not close the stream first.
+        buffer = +""
+        response.read_body do |chunk|
+          buffer << chunk
+          while (boundary = /\r?\n\r?\n/.match(buffer))
+            event = buffer.slice!(0, boundary.end(0))
+            data = event.lines.filter_map do |line|
+              line.delete_prefix("data:").delete_prefix(" ").chomp if line.start_with?("data:")
+            end.join("\n")
+            next if data.empty?
+
+            parsed = JSON.parse(data)
+            return parsed if matching_response?(parsed, request_id)
+          end
+        end
+      else
+        parsed = JSON.parse(response.body.to_s)
+        return parsed if matching_response?(parsed, request_id)
+      end
+      raise Error, "MCP server did not return a response for request #{request_id}"
+    rescue JSON::ParserError
+      raise Error, "MCP server returned invalid JSON"
+    end
+
+    def matching_response?(body, request_id)
+      body.is_a?(Hash) && body["jsonrpc"] == "2.0" && body["id"] == request_id &&
+        (body.key?("result") || body.key?("error"))
+    end
+
+    def ipv4_address
+      return @ipv4_address if defined?(@ipv4_address)
+
+      @ipv4_address = Resolv.getaddresses(@uri.host).find { |address| address =~ Resolv::IPv4::Regex }
+    rescue Resolv::ResolvError
+      @ipv4_address = nil
+    end
+
+    def next_id
+      @id_mutex.synchronize { @id = (@id || 0) + 1 }
+    end
+  end
+end

--- a/actionagent/app/services/action_agent/mcp_tool_binding.rb
+++ b/actionagent/app/services/action_agent/mcp_tool_binding.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module ActionAgent
+  # Binds selected agent tools to enabled MCP servers. Catalog hints and
+  # configured tool names establish ownership, but every offered schema comes
+  # from tools/list on the server that will execute the call. The caller still
+  # owns the agent.tools allowlist: discovery never adds tools to that list.
+  class MCPToolBinding
+    class Error < StandardError; end
+
+    HTTP_TRANSPORTS = %w[http streamable_http streamable-http].freeze
+    NAMESPACE = /\Amcp__([^\s]+?)__(.+)\z/
+
+    def initialize(agent)
+      @servers = EvaluationToolResolver.new(agent).configured_servers.map do |entry|
+        catalog = MCPCatalog.find(entry[:key]) || {}
+        catalog.merge(entry).merge(tools: entry[:tools] || entry[:tool_hints] || catalog[:tools])
+      end.uniq { |server| server[:key] }
+      @bindings = {}
+      @clients = {}
+      @definitions = {}
+      @discovery_errors = {}
+    end
+
+    # Returns nil for a tool no enabled server owns, or a binding containing
+    # its wire name, server, client and provider-neutral definition. Explicit
+    # MCP claims that cannot execute raise instead of falling back to a local
+    # toolbox implementation with the same name.
+    def resolve(tool_name)
+      name = tool_name.to_s
+      return @bindings[name] if @bindings.key?(name)
+
+      @bindings[name] = resolve_binding(name)
+    end
+
+    private
+
+    def resolve_binding(name)
+      if (namespace = NAMESPACE.match(name))
+        key, wire_name = namespace.captures
+        server = @servers.find { |entry| entry[:key] == key.downcase }
+        raise Error, "MCP server '#{key}' is not enabled for this agent; enable it before selecting '#{name}'" unless server
+
+        return bind(server, name, wire_name)
+      end
+      return nil if @servers.empty?
+
+      claims = @servers.select { |server| declared_tool_names(server).include?(name) }
+      reject_ambiguous!(name, claims)
+      return bind(claims.first, name, name) if claims.one?
+
+      # Hints are not exhaustive. Discover additional bare names on enabled
+      # HTTP servers, while leaving unrelated stdio servers alone. Selecting
+      # a hinted or namespaced stdio tool above still raises an actionable
+      # unsupported-transport error rather than executing a toolbox fallback.
+      matches = @servers.select do |server|
+        discoverable?(server) && definitions_for(server).any? { |tool| tool["name"] == name }
+      end
+      reject_ambiguous!(name, matches)
+      bind(matches.first, name, name) if matches.one?
+    end
+
+    def declared_tool_names(server)
+      Array(server[:tools]).filter_map do |tool|
+        name = tool.respond_to?(:key?) ? tool["name"] || tool[:name] : tool
+        next if name.to_s.empty?
+
+        if (namespace = NAMESPACE.match(name.to_s))
+          namespace[2] if namespace[1].downcase == server[:key]
+        else
+          name.to_s
+        end
+      end
+    end
+
+    def discoverable?(server)
+      transport = server[:transport].to_s.downcase
+      HTTP_TRANSPORTS.include?(transport) || (transport.empty? && server[:url].present?)
+    end
+
+    def reject_ambiguous!(name, servers)
+      return if servers.size < 2
+
+      keys = servers.map { |server| server[:key] }.join(", ")
+      raise Error, "MCP tool '#{name}' is ambiguous across enabled servers: #{keys}; select mcp__SERVER__#{name}"
+    end
+
+    def bind(server, name, wire_name)
+      tool = definitions_for(server).find { |definition| definition["name"] == wire_name }
+      unless tool
+        raise Error, "MCP server '#{server[:key]}' does not offer selected tool '#{wire_name}'; check tools/list or update the agent's tools"
+      end
+      unless tool["inputSchema"].is_a?(Hash)
+        raise Error, "MCP server '#{server[:key]}' returned no valid inputSchema for '#{wire_name}'; fix its tools/list response"
+      end
+
+      {
+        name: wire_name,
+        server: server[:key],
+        client: @clients.fetch(server[:key]),
+        definition: {
+          name: name,
+          description: tool["description"].presence || "Call #{wire_name} on MCP server '#{server[:key]}'",
+          parameters: tool["inputSchema"]
+        }
+      }
+    end
+
+    def definitions_for(server)
+      key = server[:key]
+      raise @discovery_errors[key] if @discovery_errors.key?(key)
+      return @definitions[key] if @definitions.key?(key)
+
+      client = @clients[key] ||= MCPClient.new(url: server[:url], transport: server[:transport].presence || "http")
+      tools = client.list_tools
+      unless tools.is_a?(Array) && tools.all? { |tool| tool.is_a?(Hash) }
+        raise Error, "tools/list must return an array of tool definitions"
+      end
+      @definitions[key] = tools.map(&:stringify_keys)
+    rescue StandardError => error
+      @discovery_errors[key] ||= Error.new(
+        "Cannot load tools from MCP server '#{key}': #{error.message}. Check its MCP server URL and transport"
+      )
+      raise @discovery_errors[key]
+    end
+  end
+end

--- a/actionagent/app/services/action_agent/playwright_mcp_client.rb
+++ b/actionagent/app/services/action_agent/playwright_mcp_client.rb
@@ -1,20 +1,10 @@
 # frozen_string_literal: true
 
 module ActionAgent
-  require "net/http"
-  require "resolv"
-
-  # Minimal MCP client (streamable HTTP transport) for a Playwright MCP
-  # server — typically `npx @playwright/mcp --port 8931` running beside the
-  # app in development, or a sandbox-provisioned browser container in
-  # production. Speaks just enough JSON-RPC for tools/call: initialize once
-  # per process, then call tools under the session id the server hands back.
-  class PlaywrightMCPClient
+  # Browser callers retain their default endpoint and process singleton;
+  # discovery and transport are shared with configured MCP services.
+  class PlaywrightMCPClient < MCPClient
     DEFAULT_URL = ENV.fetch("PLAYWRIGHT_MCP_URL", "http://host.orb.internal:8931/mcp")
-    OPEN_TIMEOUT_SECONDS = 5
-    READ_TIMEOUT_SECONDS = 60
-
-    class Error < StandardError; end
 
     def self.instance
       @instance ||= new
@@ -24,125 +14,15 @@ module ActionAgent
       @instance = nil
     end
 
-    def initialize(url: DEFAULT_URL)
-      @uri = URI(url)
-      @mutex = Mutex.new
-    end
-
-    # Returns { text:, is_error: } — the tool result's text content.
-    def call_tool(name, arguments = {})
-      Rails.logger.debug("[PlaywrightMCPClient] call #{name} args=#{arguments.inspect[0, 200]}")
-      ensure_session!
-      response = post(
-        { jsonrpc: "2.0", id: next_id, method: "tools/call",
-          params: { name: name, arguments: arguments } },
-        session: @session_id
-      )
-      result = response["result"]
-      unless result
-        Rails.logger.warn("[PlaywrightMCPClient] #{name} unexpected response: #{response.inspect[0, 500]}")
-        raise Error, (response.dig("error", "message") || "empty MCP response")
-      end
-
-      text = Array(result["content"]).filter_map { |block| block["text"] }.join("\n")
-      { text: text, is_error: result["isError"] ? true : false }
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Net::OpenTimeout, SocketError => e
-      self.class.reset!
-      raise Error, "Playwright MCP server unreachable at #{@uri} (#{e.class}): start it with `npx @playwright/mcp --port 8931`"
+    def initialize(url: DEFAULT_URL, transport: "http")
+      super
     end
 
     private
 
-    def ensure_session!
-      @mutex.synchronize do
-        next if @session_id
-
-        _body, response = post_raw(
-          { jsonrpc: "2.0", id: next_id, method: "initialize",
-            params: { protocolVersion: "2025-03-26", capabilities: {},
-                      clientInfo: { name: "activeagents", version: "1.0" } } }
-        )
-        @session_id = response["mcp-session-id"]
-        raise Error, "MCP server did not return a session id" unless @session_id
-
-        post({ jsonrpc: "2.0", method: "notifications/initialized" }, session: @session_id)
-      end
-    end
-
-    def post(payload, session: nil)
-      body, _response = post_raw(payload, session: session)
-      body
-    end
-
-    def post_raw(payload, session: nil)
-      # Tool calls run inside the provider SDK's streaming enumerator — a
-      # fiber, where Net::HTTP reads of SSE bodies misbehave (headers arrive,
-      # body comes back empty). A dedicated thread always does real blocking
-      # IO outside any fiber/scheduler context.
-      Thread.new { blocking_post_raw(payload, session: session) }.value
-    end
-
-    def blocking_post_raw(payload, session: nil)
-      http = Net::HTTP.new(@uri.host, @uri.port)
-      # Container->host bridge hostnames (host.orb.internal) publish an IPv6
-      # address whose path doesn't reach the server; dual-stack connects then
-      # fail intermittently. Pin to IPv4 while keeping the Host header.
-      if (ipv4 = ipv4_address)
-        http.ipaddr = ipv4
-      end
-      http.open_timeout = OPEN_TIMEOUT_SECONDS
-      http.read_timeout = READ_TIMEOUT_SECONDS
-      request = Net::HTTP::Post.new(@uri.request_uri)
-      request["Content-Type"] = "application/json"
-      request["Accept"] = "application/json, text/event-stream"
-      request["Mcp-Session-Id"] = session if session
-      request.body = payload.to_json
-
-      response = http.request(request)
-      Rails.logger.debug(
-        "[PlaywrightMCPClient] #{payload[:method]} -> #{response.code} " \
-        "ct=#{response['Content-Type']} bytes=#{response.body.to_s.bytesize} session=#{session ? 'yes' : 'no'}"
-      )
-      unless response.code.to_i.between?(200, 299)
-        Rails.logger.warn("[PlaywrightMCPClient] HTTP #{response.code}: #{response.body.to_s[0, 300]}")
-        raise Error, "MCP server returned HTTP #{response.code}"
-      end
-
-      parsed = parse_body(response)
-      if parsed.empty? && payload[:id]
-        Rails.logger.warn("[PlaywrightMCPClient] unparsed body (#{response['Content-Type']}): #{response.body.to_s[0, 500]}")
-      end
-      [ parsed, response ]
-    end
-
-    # Streamable HTTP answers as plain JSON or as an SSE stream whose data:
-    # lines carry the JSON-RPC response — accept both.
-    def parse_body(response)
-      body = response.body.to_s
-      return {} if body.empty?
-
-      if response["Content-Type"].to_s.include?("text/event-stream")
-        body.lines
-            .select { |line| line.start_with?("data:") }
-            .filter_map { |line| JSON.parse(line.delete_prefix("data:").strip) rescue nil }
-            .find { |json| json["result"] || json["error"] } || {}
-      else
-        JSON.parse(body)
-      end
-    rescue JSON::ParserError
-      {}
-    end
-
-    def ipv4_address
-      return @ipv4_address if defined?(@ipv4_address)
-
-      @ipv4_address = Resolv.getaddresses(@uri.host).find { |address| address =~ Resolv::IPv4::Regex }
-    rescue Resolv::ResolvError
-      @ipv4_address = nil
-    end
-
-    def next_id
-      @id = (@id || 0) + 1
+    def reset_session!
+      super
+      self.class.reset!
     end
   end
 end

--- a/actionagent/app/services/action_agent/scenario_evaluation_runner.rb
+++ b/actionagent/app/services/action_agent/scenario_evaluation_runner.rb
@@ -207,8 +207,16 @@ module ActionAgent
     end
 
     def tool_roster
-      @tool_roster ||= AgentToolbox.definitions_for(@evaluation.agent.tools).to_h do |definition|
-        [ definition[:name].to_s, definition[:description].to_s ]
+      # Use the same contract as execution, including MCP tools named like
+      # builder categories (e.g. "memory"). Discovery failures are retried
+      # inside each replay, where they become persisted run_error results
+      # rather than aborting the suite while preparing the judge's context.
+      @tool_roster ||= begin
+        AgentExecutionService.new(@evaluation.agent, nil).resolved_tool_schemas.to_h do |definition|
+          [ definition[:name].to_s, definition[:description].to_s ]
+        end
+      rescue AgentExecutionService::ToolNotConfiguredError, MCPToolBinding::Error
+        Array(@evaluation.agent.tools).to_h { |name| [ name.to_s, "" ] }
       end
     end
 

--- a/actionagent/lib/action_agent/engine.rb
+++ b/actionagent/lib/action_agent/engine.rb
@@ -19,9 +19,11 @@ module ActionAgent
     # rather than relying on the host to register one.
     INFLECTION_OVERRIDES = {
       "mcp_catalog" => "MCPCatalog",
+      "mcp_client" => "MCPClient",
       "mcp_controller" => "MCPController",
       "mcp_recording_middleware" => "MCPRecordingMiddleware",
       "mcp_servers_controller" => "MCPServersController",
+      "mcp_tool_binding" => "MCPToolBinding",
       "playwright_mcp_client" => "PlaywrightMCPClient"
     }.freeze
 

--- a/actionagent/test/agent_mcp_execution_test.rb
+++ b/actionagent/test/agent_mcp_execution_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "telemetry_trace_test"
+
+class AgentMCPExecutionTest < ActiveSupport::TestCase
+  TelemetryTraceTest.ensure_table!
+  class Client
+    attr_reader :calls, :lists
+    attr_accessor :result
+
+    def initialize(names)
+      @names = names
+      @calls = []
+      @lists = 0
+      @result = { text: "Host database is healthy", is_error: false }
+    end
+
+    def list_tools
+      @lists += 1
+      @names.map do |name|
+        { "name" => name, "description" => "Host #{name}",
+          "inputSchema" => { "type" => "object", "properties" => { "service" => { "type" => "string" } },
+                             "required" => [ "service" ] } }
+      end
+    end
+
+    def call_tool(name, arguments)
+      @calls << [ name, arguments ]
+      raise result if result.is_a?(Exception)
+
+      result
+    end
+  end
+
+  setup do
+    @original_catalog = ActionAgent.mcp_catalog
+    ActionAgent.mcp_catalog = [ { key: "host", name: "Host", transport: "http", url: "https://host.example/mcp",
+                                 tool_hints: %w[healthcheck calculate] } ]
+    @agent = ActionAgent::Agent.create!(name: "Host assistant", provider: "mock", model: "mock",
+      tools: [ "healthcheck" ], mcp_servers: [ "host" ])
+    @run = @agent.agent_runs.create!(input_prompt: "Check database health", status: :running, trace_id: SecureRandom.hex(16))
+    @service = ActionAgent::AgentExecutionService.new(@agent, @run)
+  end
+
+  teardown do
+    ActionAgent.mcp_catalog = @original_catalog
+  end
+
+  test "live MCP schemas and calls use the same session and selected tool roster" do
+    client = Client.new(%w[healthcheck calculate])
+    ActionAgent::MCPClient.stub(:new, client) do
+      schemas = @service.resolved_tool_schemas
+      assert_equal [ "healthcheck" ], schemas.map { |definition| definition[:name] }
+      assert_equal [ "service" ], schemas.first[:parameters]["required"]
+
+      2.times { assert_equal client.result, @service.execute_tool("healthcheck", service: "database") }
+      assert_equal 1, client.lists
+      assert_equal [ [ "healthcheck", { service: "database" } ] ] * 2, client.calls
+      assert_raises(ActionAgent::AgentExecutionService::ToolNotConfiguredError) do
+        @service.execute_tool("calculate", expression: "1 + 1")
+      end
+    end
+  end
+
+  test "namespaced calls keep their offered name and dispatch the bare MCP name" do
+    @agent.tools = [ "mcp__host__healthcheck" ]
+    root = ActiveAgent::Telemetry::Span.new("agent", trace_id: @run.trace_id, span_type: :root)
+    @service.instance_variable_set(:@root_span, root)
+    client = Client.new([ "healthcheck" ])
+
+    ActionAgent::MCPClient.stub(:new, client) do
+      assert_equal [ "mcp__host__healthcheck" ], @service.resolved_tool_schemas.map { |definition| definition[:name] }
+      @service.execute_tool("mcp__host__healthcheck", service: "database")
+    end
+
+    assert_equal [ [ "healthcheck", { service: "database" } ] ], client.calls
+    assert_equal "mcp__host__healthcheck", @run.reload.logs.first["label"]
+    attributes = root.children.first.to_h["attributes"]
+    assert_equal "host", attributes["tool.mcp_server"]
+    assert_equal "mcp", attributes["tool.origin"]
+  end
+
+  test "an enabled MCP claim takes precedence over toolbox functions" do
+    @agent.tools = [ "code" ]
+    client = Client.new([ "calculate" ])
+
+    ActionAgent::MCPClient.stub(:new, client) do
+      assert_equal "Host calculate", @service.resolved_tool_schemas.first[:description]
+      assert_equal client.result, @service.execute_tool("calculate", expression: "1 + 1")
+    end
+    assert_equal [ [ "calculate", { expression: "1 + 1" } ] ], client.calls
+  end
+
+  test "builtin categories and exact function names work without enabled MCP servers" do
+    @agent.tools = %w[code calculate memory]
+    @agent.mcp_servers = []
+
+    assert_equal %w[calculate save_memory recall_memory], @service.resolved_tool_schemas.map { |definition| definition[:name] }
+    assert_equal 2, @service.execute_tool("calculate", expression: "1 + 1")[:result]
+    saved = @service.execute_tool("save_memory", content: "Remember the healthcheck")
+    assert saved[:saved]
+    assert_equal "Remember the healthcheck", @service.execute_tool("recall_memory")[:entries].first[:content]
+  end
+
+  test "an exact host tool takes precedence over a builder category with the same name" do
+    @agent.tools = [ "memory" ]
+    client = Client.new([ "memory" ])
+
+    ActionAgent::MCPClient.stub(:new, client) do
+      assert_equal [ "memory" ], @service.resolved_tool_schemas.map { |definition| definition[:name] }
+      assert_equal client.result, @service.execute_tool("memory", service: "database")
+    end
+    assert_equal [ [ "memory", { service: "database" } ] ], client.calls
+  end
+
+  test "unresolved declarations fail before generation and are recorded as execution errors" do
+    @agent.tools = %w[code healthcheck unknown_tool]
+    @agent.mcp_servers = []
+
+    @service.stub(:generate!, -> { flunk "The provider must not run with a partial tool roster" }) do
+      error = assert_raises(ActionAgent::AgentExecutionService::ToolNotConfiguredError) { @service.call }
+      assert_includes error.message, "healthcheck, unknown_tool"
+      assert_includes error.message, "MCP server"
+    end
+
+    assert @run.reload.logs.any? { |event| event["status"] == "error" }
+    trace = ActionAgent::TelemetryTrace.find_by!(trace_id: @run.trace_id)
+    assert_equal "ERROR", trace.status
+  end
+
+  test "a synchronous run with an unbound tool fails instead of fabricating an answer" do
+    @agent.update!(tools: [ "unknown_tool" ], mcp_servers: [])
+
+    run = @agent.test_execute("Run a healthcheck")
+
+    assert run.failed?
+    assert_nil run.output
+    assert_includes run.error_message, "unknown_tool"
+  end
+
+  test "MCP tool errors and transport exceptions reach error events without toolbox fallback" do
+    @agent.tools = [ "calculate" ]
+    client = Client.new([ "calculate" ])
+    client.result = { text: "Host database unavailable", is_error: true }
+
+    ActionAgent::MCPClient.stub(:new, client) do
+      assert_equal client.result, @service.execute_tool("calculate", expression: "1 + 1")
+      client.result = ActionAgent::MCPClient::Error.new("Connection lost")
+      result = @service.execute_tool("calculate", expression: "1 + 1")
+      assert_includes result[:error], "Connection lost"
+    end
+
+    errors = @run.reload.logs.select { |event| event["status"] == "error" }
+    assert_equal 2, errors.size
+    assert_equal "Host database unavailable", errors.first["detail"]
+    assert_equal 2, client.calls.size
+  end
+end

--- a/actionagent/test/mcp_client_test.rb
+++ b/actionagent/test/mcp_client_test.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MCPClientTest < ActiveSupport::TestCase
+  URL = "https://127.0.0.1:8931/mcp"
+  SCHEMA = {
+    "type" => "object",
+    "properties" => { "query" => { "type" => "string" } },
+    "required" => [ "query" ], "additionalProperties" => false
+  }.freeze
+  TOOL = { "name" => "search", "description" => "Search records", "inputSchema" => SCHEMA }.freeze
+
+  teardown do
+    ActionAgent::PlaywrightMCPClient.reset!
+  end
+
+  test "initializes over HTTPS once and forwards negotiated headers on discovery and calls" do
+    initialization = stub_initialization(session: "test-session", version: "2025-03-26")
+    listing = stub_rpc("tools/list", result: { tools: [ TOOL ] })
+      .with(headers: { "Mcp-Session-Id" => "test-session", "MCP-Protocol-Version" => "2025-03-26" })
+    calling = stub_rpc("tools/call", result: { content: [ { type: "text", text: "found" } ] })
+      .with(headers: { "Mcp-Session-Id" => "test-session", "MCP-Protocol-Version" => "2025-03-26" }) { |req|
+        JSON.parse(req.body)["params"] == { "name" => "search", "arguments" => { "query" => "hello" } }
+      }
+
+    client = ActionAgent::MCPClient.new(url: URL)
+    assert_equal [ TOOL ], client.list_tools
+    assert_equal [ TOOL ], client.list_tools
+    assert_equal({ text: "found", is_error: false }, client.call_tool("search", query: "hello"))
+    assert_requested initialization, times: 1
+    assert_requested listing, times: 2
+    assert_requested calling, times: 1
+    assert_requested :post, URL, times: 1 do |req|
+      payload = JSON.parse(req.body)
+      payload["method"] == "initialize" && !req.headers.key?("Mcp-Session-Id") &&
+        payload.dig("params", "protocolVersion") == ActionAgent::MCPClient::PROTOCOL_VERSION &&
+        payload.dig("params", "capabilities") == {}
+    end
+  end
+
+  test "stateless servers need no session id and are initialized only once" do
+    initialization = stub_initialization
+    stub_rpc("tools/list", result: { tools: [] })
+    stub_rpc("tools/call", result: { content: [] })
+
+    client = ActionAgent::MCPClient.new(url: URL, transport: nil)
+    assert_empty client.list_tools
+    assert_equal({ text: "", is_error: false }, client.call_tool("noop"))
+    assert_requested initialization, times: 1
+    assert_requested :post, URL, times: 4 do |req|
+      !req.headers.key?("Mcp-Session-Id")
+    end
+  end
+
+  test "discovery follows pagination and retains each input schema" do
+    stub_initialization
+    listing = stub_request(:post, URL).with { |req| JSON.parse(req.body)["method"] == "tools/list" }
+      .to_return do |req|
+        payload = JSON.parse(req.body)
+        result = if payload["params"].empty?
+          { tools: [ TOOL ], nextCursor: "second" }
+        else
+          assert_equal({ "cursor" => "second" }, payload["params"])
+          { tools: [ TOOL.merge("name" => "lookup") ] }
+        end
+        rpc_response(payload["id"], result)
+      end
+
+    tools = ActionAgent::MCPClient.new(url: URL).list_tools
+    assert_equal [ "search", "lookup" ], tools.map { |tool| tool["name"] }
+    assert_equal [ SCHEMA, SCHEMA ], tools.map { |tool| tool["inputSchema"] }
+    assert_requested listing, times: 2
+  end
+
+  test "a repeated pagination cursor fails rather than looping" do
+    stub_initialization
+    listing = stub_rpc("tools/list", result: { tools: [], nextCursor: "same" })
+
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_match(/repeated cursor/, error.message)
+    assert_requested listing, times: 2
+  end
+
+  test "SSE responses support multiline data and ignore notifications and unrelated ids" do
+    stub_initialization
+    stub_request(:post, URL).with { |req| JSON.parse(req.body)["method"] == "tools/list" }
+      .to_return do |req|
+        payload = JSON.parse(req.body)
+        message = { jsonrpc: "2.0", id: payload["id"], result: { tools: [ TOOL ] } }
+        data = JSON.pretty_generate(message).lines.map { |line| "data: #{line.chomp}\r\n" }.join
+        {
+          status: 200, headers: { "Content-Type" => "text/event-stream" },
+          body: ": keepalive\r\n\r\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}\r\n\r\n" \
+            "data: {\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{}}\r\n\r\nevent: message\r\n#{data}\r\n"
+        }
+      end
+
+    assert_equal [ TOOL ], ActionAgent::MCPClient.new(url: URL).list_tools
+  end
+
+  test "tool failures remain result values and structured output is preserved" do
+    stub_initialization
+    stub_rpc("tools/call", result: {
+      content: [ { type: "text", text: "first" }, { type: "image", data: "image" }, { type: "text", text: "second" } ],
+      isError: true, structuredContent: { reason: "missing record" }
+    })
+
+    result = ActionAgent::MCPClient.new(url: URL).call_tool("search", query: "missing")
+    assert_equal "first\nsecond", result[:text]
+    assert result[:is_error]
+    assert_equal({ "reason" => "missing record" }, result[:structured_content])
+  end
+
+  test "structured-only tool results provide text for existing tool consumers" do
+    stub_initialization
+    stub_rpc("tools/call", result: { structuredContent: { count: 3 } })
+
+    result = ActionAgent::MCPClient.new(url: URL).call_tool("count")
+    assert_equal({ "count" => 3 }, JSON.parse(result[:text]))
+    assert_equal({ "count" => 3 }, result[:structured_content])
+  end
+
+  test "JSON-RPC failures raise a client error" do
+    stub_initialization
+    stub_request(:post, URL).with { |req| JSON.parse(req.body)["method"] == "tools/list" }
+      .to_return do |req|
+        {
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: JSON.generate(jsonrpc: "2.0", id: JSON.parse(req.body)["id"], error: { code: -32601, message: "Tools unavailable" })
+        }
+      end
+
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_match(/-32601.*Tools unavailable/, error.message)
+  end
+
+  test "HTTP failures raise a client error without exposing response contents" do
+    stub_initialization
+    stub_rpc("tools/list", status: 403, result: { secret: "private error detail" })
+
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_equal "MCP server returned HTTP 403", error.message
+  end
+
+  test "expired sessions are initialized again and the rejected request is retried once" do
+    initialization = stub_initialization(session: "test-session")
+    listing = stub_request(:post, URL).with { |req| JSON.parse(req.body)["method"] == "tools/list" }
+      .to_return(status: 404).then.to_return { |req| rpc_response(JSON.parse(req.body)["id"], { tools: [ TOOL ] }) }
+
+    assert_equal [ TOOL ], ActionAgent::MCPClient.new(url: URL).list_tools
+    assert_requested initialization, times: 2
+    assert_requested listing, times: 2
+  end
+
+  test "a session that keeps expiring stops retrying" do
+    initialization = stub_initialization(session: "test-session")
+    listing = stub_rpc("tools/list", status: 404)
+
+    assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_requested initialization, times: 2
+    assert_requested listing, times: 2
+  end
+
+  test "connection timeouts do not retry potentially executed tool calls" do
+    stub_initialization
+    calling = stub_request(:post, URL).with { |req| JSON.parse(req.body)["method"] == "tools/call" }.to_timeout
+
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).call_tool("write") }
+    assert_match(/connection failed/, error.message)
+    assert_requested calling, times: 1
+  end
+
+  test "invalid JSON and unmatched response ids fail clearly" do
+    stub_initialization
+    listing = stub_request(:post, URL).with { |req| JSON.parse(req.body)["method"] == "tools/list" }
+    listing.to_return(body: "not json", headers: { "Content-Type" => "application/json" })
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_match(/invalid JSON/, error.message)
+
+    listing.to_return(rpc_response(999, { tools: [] }))
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_match(/did not return a response/, error.message)
+  end
+
+  test "malformed tool lists fail instead of silently hiding tools" do
+    stub_initialization
+    stub_rpc("tools/list", result: { tools: { search: {} } })
+
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_match(/tools array/, error.message)
+  end
+
+  test "unsupported protocol versions stop before announcing initialization" do
+    stub_rpc("initialize", result: { protocolVersion: "2099-01-01" })
+
+    error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL).list_tools }
+    assert_match(/Unsupported MCP protocol version/, error.message)
+    assert_not_requested :post, URL do |req|
+      JSON.parse(req.body)["method"] == "notifications/initialized"
+    end
+  end
+
+  test "unsupported transports and invalid endpoints fail before making requests" do
+    [ "stdio", "sse" ].each do |transport|
+      error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: URL, transport: transport) }
+      assert_match(/Unsupported MCP transport/, error.message)
+    end
+    [ "/mcp", "file:///tmp/mcp", "not a URL" ].each do |url|
+      error = assert_raises(ActionAgent::MCPClient::Error) { ActionAgent::MCPClient.new(url: url) }
+      assert_match(/absolute HTTP or HTTPS/, error.message)
+    end
+    assert_instance_of ActionAgent::MCPClient, ActionAgent::MCPClient.new(url: URL, transport: "streamable-http")
+    assert_instance_of ActionAgent::MCPClient, ActionAgent::MCPClient.new(url: URL, transport: "streamable_http")
+  end
+
+  test "Playwright client keeps the singleton and tool-result interface" do
+    original = ActionAgent::PlaywrightMCPClient.instance
+    assert_kind_of ActionAgent::MCPClient, original
+    assert_same original, ActionAgent::PlaywrightMCPClient.instance
+    ActionAgent::PlaywrightMCPClient.reset!
+    refute_same original, ActionAgent::PlaywrightMCPClient.instance
+
+    stub_initialization(session: "browser-session")
+    stub_rpc("tools/call", result: { content: [ { type: "text", text: "snapshot" } ] })
+    result = ActionAgent::PlaywrightMCPClient.new(url: URL).call_tool("browser_snapshot")
+    assert_equal({ text: "snapshot", is_error: false }, result)
+  end
+
+  private
+
+  def stub_initialization(session: nil, version: ActionAgent::MCPClient::PROTOCOL_VERSION)
+    headers = session ? { "Mcp-Session-Id" => session } : {}
+    initialization = stub_rpc("initialize", result: {
+      protocolVersion: version, capabilities: { tools: {} }, serverInfo: { name: "test", version: "1.0" }
+    }, headers: headers)
+    notification = stub_rpc("notifications/initialized", status: 202)
+    notification.with(headers: { "MCP-Protocol-Version" => version }.merge(headers))
+    initialization
+  end
+
+  def stub_rpc(method, result: nil, status: 200, headers: {})
+    stub_request(:post, URL)
+      .with(body: hash_including("method" => method),
+        headers: { "Content-Type" => "application/json", "Accept" => "application/json, text/event-stream" })
+      .to_return do |req|
+        rpc_response(JSON.parse(req.body)["id"], result).merge(status: status,
+          headers: { "Content-Type" => "application/json" }.merge(headers))
+      end
+  end
+
+  def rpc_response(id, result)
+    {
+      status: 200, headers: { "Content-Type" => "application/json" },
+      body: id ? JSON.generate(jsonrpc: "2.0", id: id, result: result) : ""
+    }
+  end
+end

--- a/actionagent/test/mcp_tool_binding_test.rb
+++ b/actionagent/test/mcp_tool_binding_test.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MCPToolBindingTest < ActiveSupport::TestCase
+  AgentConfig = Struct.new(:mcp_servers)
+  FakeClient = Struct.new(:tools, :list_calls, :failure) do
+    def list_tools
+      self.list_calls += 1
+      raise failure if failure
+
+      tools
+    end
+  end
+
+  setup do
+    @previous_catalog = ActionAgent.mcp_catalog
+    ActionAgent.mcp_catalog = [
+      {
+        key: "warehouse", name: "Warehouse", transport: "http",
+        url: "https://warehouse.example/mcp", tool_hints: [ "lookup" ]
+      }
+    ]
+    @schema = {
+      "type" => "object",
+      "properties" => { "sku" => { "type" => "string" } },
+      "required" => [ "sku" ], "additionalProperties" => false
+    }
+  end
+
+  teardown do
+    ActionAgent.mcp_catalog = @previous_catalog
+  end
+
+  test "catalog availability never enables a server or its tools" do
+    ActionAgent::MCPClient.stub(:new, ->(**) { flunk "disabled servers must not be contacted" }) do
+      resolver = resolver_for([])
+      assert_nil resolver.resolve("lookup")
+      error = assert_raises(ActionAgent::MCPToolBinding::Error) { resolver.resolve("mcp__warehouse__lookup") }
+      assert_includes error.message, "not enabled"
+    end
+  end
+
+  test "bare names builder hashes and legacy keyed hashes merge catalog connection settings" do
+    configurations = [
+      [ "warehouse" ],
+      [ { "name" => "Warehouse", "key" => " WAREHOUSE " } ],
+      { "warehouse" => {} }
+    ]
+
+    configurations.each do |configuration|
+      client = fake_client("lookup")
+      with_clients("https://warehouse.example/mcp" => client) do |connections|
+        binding = resolver_for(configuration).resolve("lookup")
+        assert_equal "warehouse", binding[:server]
+        assert_equal @schema, binding.dig(:definition, :parameters)
+        assert_equal [ { url: "https://warehouse.example/mcp", transport: "http" } ], connections
+      end
+    end
+  end
+
+  test "inline URL and transport override the catalog and use the live schema" do
+    client = fake_client("lookup")
+    configuration = [
+      {
+        name: "warehouse", url: "https://override.example/mcp", transport: "streamable_http",
+        tools: [ { name: "lookup", inputSchema: { type: "object", properties: {} } } ]
+      }
+    ]
+
+    with_clients("https://override.example/mcp" => client) do |connections|
+      binding = resolver_for(configuration).resolve("lookup")
+      assert_equal "Look up lookup", binding.dig(:definition, :description)
+      assert_equal @schema, binding.dig(:definition, :parameters)
+      assert_equal "streamable_http", connections.first[:transport]
+    end
+  end
+
+  test "namespaced tools keep their offered name and strip only their server prefix on the wire" do
+    client = fake_client("lookup__details")
+
+    with_clients("https://warehouse.example/mcp" => client) do
+      binding = resolver_for([ "warehouse" ]).resolve("mcp__warehouse__lookup__details")
+      assert_equal "lookup__details", binding[:name]
+      assert_equal "mcp__warehouse__lookup__details", binding.dig(:definition, :name)
+      assert_same client, binding[:client]
+    end
+  end
+
+  test "explicit namespaced tool declarations also claim their bare name" do
+    configuration = [
+      { key: "warehouse", tools: [ "mcp__warehouse__lookup" ] },
+      { key: "unreachable", url: "https://unreachable.example/mcp" }
+    ]
+
+    with_clients("https://warehouse.example/mcp" => fake_client("lookup")) do |connections|
+      assert_equal "warehouse", resolver_for(configuration).resolve("lookup")[:server]
+      assert_equal 1, connections.length
+    end
+  end
+
+  test "catalog hints are not exhaustive and additional bare tools are discovered live" do
+    client = fake_client("reserve")
+
+    with_clients("https://warehouse.example/mcp" => client) do
+      binding = resolver_for([ "warehouse" ]).resolve("reserve")
+      assert_equal "reserve", binding[:name]
+      assert_equal @schema, binding.dig(:definition, :parameters)
+    end
+  end
+
+  test "servers without declarations discover tools with an inline URL and default transport" do
+    configuration = { "private" => { "url" => "https://private.example/mcp" } }
+
+    with_clients("https://private.example/mcp" => fake_client("reserve")) do
+      assert_equal "private", resolver_for(configuration).resolve("reserve")[:server]
+    end
+  end
+
+  test "discovery and bindings reuse the same client and tool list within a run" do
+    client = fake_client("lookup", "reserve")
+
+    with_clients("https://warehouse.example/mcp" => client) do |connections|
+      resolver = resolver_for([ "warehouse", "warehouse" ])
+      binding = resolver.resolve("lookup")
+      assert_same binding, resolver.resolve("lookup")
+      assert_same client, resolver.resolve("reserve")[:client]
+      assert_nil resolver.resolve("unrelated")
+      assert_nil resolver.resolve("unrelated")
+      assert_equal 1, client.list_calls
+      assert_equal 1, connections.length
+    end
+  end
+
+  test "an enabled server claim missing from tools list fails instead of allowing fallback" do
+    with_clients("https://warehouse.example/mcp" => fake_client("different")) do
+      error = assert_raises(ActionAgent::MCPToolBinding::Error) do
+        resolver_for([ "warehouse" ]).resolve("lookup")
+      end
+      assert_includes error.message, "warehouse"
+      assert_includes error.message, "does not offer selected tool 'lookup'"
+    end
+  end
+
+  test "an unreachable claimed server produces a cached actionable failure" do
+    client = FakeClient.new([], 0, ActionAgent::MCPClient::Error.new("connection refused"))
+
+    with_clients("https://warehouse.example/mcp" => client) do
+      resolver = resolver_for([ "warehouse" ])
+      2.times do
+        error = assert_raises(ActionAgent::MCPToolBinding::Error) { resolver.resolve("lookup") }
+        assert_includes error.message, "warehouse"
+        assert_includes error.message, "connection refused"
+        assert_includes error.message, "URL and transport"
+      end
+      assert_equal 1, client.list_calls
+    end
+  end
+
+  test "unclaimed HTTP discovery failures are actionable" do
+    client = FakeClient.new([], 0, ActionAgent::MCPClient::Error.new("connection refused"))
+
+    with_clients("https://warehouse.example/mcp" => client) do
+      assert_raises(ActionAgent::MCPToolBinding::Error) do
+        resolver_for([ "warehouse" ]).resolve("reserve")
+      end
+    end
+  end
+
+  test "unsupported servers are skipped for unrelated tools but fail when they claim a selected tool" do
+    resolver = resolver_for([ "filesystem" ])
+    assert_nil resolver.resolve("unrelated")
+
+    error = assert_raises(ActionAgent::MCPToolBinding::Error) { resolver.resolve("read_file") }
+    assert_includes error.message, "filesystem"
+    assert_includes error.message, "stdio"
+  end
+
+  test "ambiguous configured bare tool claims require a namespace" do
+    configuration = [
+      { key: "first", tools: [ "query" ] },
+      { key: "second", tool_hints: [ "query" ] }
+    ]
+
+    error = assert_raises(ActionAgent::MCPToolBinding::Error) { resolver_for(configuration).resolve("query") }
+    assert_includes error.message, "first, second"
+    assert_includes error.message, "mcp__SERVER__query"
+  end
+
+  test "ambiguous discovered bare tools require a namespace while explicit names select one" do
+    configuration = [
+      { key: "first", url: "https://first.example/mcp" },
+      { key: "second", url: "https://second.example/mcp" }
+    ]
+
+    with_clients(
+      "https://first.example/mcp" => fake_client("query"),
+      "https://second.example/mcp" => fake_client("query")
+    ) do
+      resolver = resolver_for(configuration)
+      assert_raises(ActionAgent::MCPToolBinding::Error) { resolver.resolve("query") }
+      assert_equal "first", resolver.resolve("mcp__first__query")[:server]
+    end
+  end
+
+  test "tools without live input schemas fail rather than inventing an empty schema" do
+    client = FakeClient.new([ { "name" => "lookup" } ], 0)
+
+    with_clients("https://warehouse.example/mcp" => client) do
+      error = assert_raises(ActionAgent::MCPToolBinding::Error) do
+        resolver_for([ "warehouse" ]).resolve("lookup")
+      end
+      assert_includes error.message, "inputSchema"
+    end
+  end
+
+  private
+
+  def resolver_for(configuration)
+    ActionAgent::MCPToolBinding.new(AgentConfig.new(configuration))
+  end
+
+  def fake_client(*names)
+    FakeClient.new(names.map { |name| { "name" => name, "description" => "Look up #{name}", "inputSchema" => @schema } }, 0)
+  end
+
+  def with_clients(clients)
+    connections = []
+    factory = lambda do |**options|
+      connections << options
+      clients.fetch(options[:url])
+    end
+    ActionAgent::MCPClient.stub(:new, factory) { yield connections }
+  end
+end

--- a/actionagent/test/run_lifecycle_test.rb
+++ b/actionagent/test/run_lifecycle_test.rb
@@ -115,25 +115,75 @@ class RunConversationTest < ActionDispatch::IntegrationTest
   end
 end
 
-# Observed agents are read-only until forked (#379).
+# Observed status records provenance rather than blocking execution (#419).
 class ObservedAgentExecutionTest < ActionDispatch::IntegrationTest
   def setup
+    @original_multi_tenant = ActionAgent.multi_tenant
     ActionAgent::AgentRun.delete_all
     ActionAgent::Agent.delete_all
+    @agent = ActionAgent::Agent.create!(
+      name: "Telemetry Only", agent_class_name: "TelemetryOnlyAgent", provider: "mock", model: "mock-model", status: :observed
+    )
   end
 
-  test "execute and test refuse a telemetry-observed agent" do
-    agent = ActionAgent::Agent.create!(
-      name: "Telemetry Only", agent_class_name: "TelemetryOnlyAgent", provider: "openai", model: "unknown", status: :observed
-    )
+  def teardown
+    ActionAgent.quota_checker = nil
+    ActionAgent.usage_recorder = nil
+    ActionAgent.execution_enabled = true
+    ActionAgent.multi_tenant = @original_multi_tenant
+  end
 
-    post "/activeagents/api/agents/#{agent.id}/execute", params: { prompt: "hello" }
-    assert_response :unprocessable_entity
-    assert_match(/read-only/, JSON.parse(response.body)["error"])
+  test "execute and test run a telemetry-observed agent and report usage" do
+    recorded = []
+    ActionAgent.usage_recorder = ->(owner, kind) { recorded << [ owner, kind ] }
 
-    post "/activeagents/api/agents/#{agent.id}/test", params: { prompt: "hello" }
-    assert_response :unprocessable_entity
+    perform_enqueued_jobs(only: ActionAgent::AgentExecutionJob) do
+      post "/activeagents/api/agents/#{@agent.id}/execute", params: { prompt: "hello" }
+    end
+    assert_response :accepted
 
-    assert_equal 0, agent.agent_runs.count, "a refused execution must not leave a failed run on the scorecard"
+    post "/activeagents/api/agents/#{@agent.id}/test", params: { prompt: "hello" }
+    assert_response :success
+
+    assert_equal [ "complete", "complete" ], @agent.agent_runs.pluck(:status)
+    assert_equal [ [ nil, :execution ], [ nil, :execution ] ], recorded
+    assert @agent.reload.observed?
+  end
+
+  test "observed execution still respects the dashboard execution switch" do
+    ActionAgent.execution_enabled = false
+
+    %w[execute test].each do |endpoint|
+      post "/activeagents/api/agents/#{@agent.id}/#{endpoint}", params: { prompt: "hello" }
+      assert_response :forbidden
+    end
+
+    assert_empty @agent.agent_runs
+    assert_no_enqueued_jobs only: ActionAgent::AgentExecutionJob
+  end
+
+  test "observed execution still respects the owner's execution quota" do
+    ActionAgent.quota_checker = ->(_owner, kind) { "Out of runs" if kind == :execution }
+
+    %w[execute test].each do |endpoint|
+      post "/activeagents/api/agents/#{@agent.id}/#{endpoint}", params: { prompt: "hello" }
+      assert_response :payment_required
+      assert_equal "Out of runs", JSON.parse(response.body)["message"]
+    end
+
+    assert_empty @agent.agent_runs
+    assert_no_enqueued_jobs only: ActionAgent::AgentExecutionJob
+  end
+
+  test "observed execution still requires an owner in a multi-tenant dashboard" do
+    ActionAgent.multi_tenant = true
+
+    %w[execute test].each do |endpoint|
+      post "/activeagents/api/agents/#{@agent.id}/#{endpoint}", params: { prompt: "hello" }
+      assert_response :unauthorized
+    end
+
+    assert_empty @agent.agent_runs
+    assert_no_enqueued_jobs only: ActionAgent::AgentExecutionJob
   end
 end

--- a/actionagent/test/scenario_evaluations_api_test.rb
+++ b/actionagent/test/scenario_evaluations_api_test.rb
@@ -7,6 +7,7 @@ require "test_helper"
 # chosen models, and reading a run's per-scenario results.
 class ActionAgentScenarioEvaluationsApiTest < ActionDispatch::IntegrationTest
   def setup
+    @original_multi_tenant = ActionAgent.multi_tenant
     ActionAgent::Agent.delete_all
   end
 
@@ -14,6 +15,7 @@ class ActionAgentScenarioEvaluationsApiTest < ActionDispatch::IntegrationTest
     ActionAgent.quota_checker = nil
     ActionAgent.usage_recorder = nil
     ActionAgent.execution_enabled = true
+    ActionAgent.multi_tenant = @original_multi_tenant
   end
 
   def create_agent(**attributes)
@@ -105,13 +107,58 @@ class ActionAgentScenarioEvaluationsApiTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "an observed agent's suite cannot be run" do
+  test "an observed agent's suite can be run without duplicating it" do
     evaluation = create_suite(create_agent(status: :observed))
+
+    perform_enqueued_jobs(only: ActionAgent::EvaluationRunJob) do
+      post "/activeagents/api/evaluations/#{evaluation.id}/run", as: :json
+    end
+
+    assert_response :success
+    assert_equal "complete", evaluation.latest_run.status
+    assert_equal "passed", evaluation.latest_run.scenario_results.first.status
+    assert evaluation.agent.reload.observed?
+  end
+
+  test "an observed agent's suite still respects execution and quota gates" do
+    evaluation = create_suite(create_agent(status: :observed))
+    ActionAgent.execution_enabled = false
+
+    post "/activeagents/api/evaluations/#{evaluation.id}/run", as: :json
+    assert_response :forbidden
+
+    ActionAgent.execution_enabled = true
+    ActionAgent.quota_checker = ->(_owner, kind) { "Out of runs" if kind == :execution }
+
+    post "/activeagents/api/evaluations/#{evaluation.id}/run", as: :json
+    assert_response :payment_required
+    assert_nil evaluation.latest_run
+    assert_no_enqueued_jobs only: ActionAgent::EvaluationRunJob
+  end
+
+  test "a scenario suite can be created and replayed for an observed agent" do
+    agent = create_agent(status: :observed)
+
+    perform_enqueued_jobs(only: ActionAgent::EvaluationRunJob) do
+      post "/activeagents/api/evaluations", params: {
+        evaluation: { agent_id: agent.id, name: "Observed suite", scenarios_text: "Hello" }
+      }, as: :json
+    end
+
+    assert_response :created
+    assert_equal "complete", agent.evaluations.last.latest_run.status
+    assert agent.reload.observed?
+  end
+
+  test "an observed agent's suite still requires an owner in a multi-tenant dashboard" do
+    evaluation = create_suite(create_agent(status: :observed))
+    ActionAgent.multi_tenant = true
 
     post "/activeagents/api/evaluations/#{evaluation.id}/run", as: :json
 
-    assert_response :unprocessable_entity
-    assert_match(/read-only/, JSON.parse(response.body)["error"])
+    assert_response :unauthorized
+    assert_nil evaluation.latest_run
+    assert_no_enqueued_jobs only: ActionAgent::EvaluationRunJob
   end
 
   test "a run can be narrowed to a group and to models, and its results are readable" do

--- a/actionagent/test/scenario_mcp_execution_test.rb
+++ b/actionagent/test/scenario_mcp_execution_test.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Exercises native scenario replay through the provider's real tool-calling
+# loop and the engine's MCP client. Only HTTP is stubbed; execution, progress
+# events, traces and evaluation results all use their production path.
+class ActionAgentScenarioMCPExecutionTest < ActiveSupport::TestCase
+  def setup
+    ActionAgent::Agent.delete_all
+    @original_catalog = ActionAgent.mcp_catalog
+    @original_credentials = ActionAgent.provider_credentials_resolver
+    ActionAgent.mcp_catalog = [ { key: "host", transport: "streamable_http", url: "https://host.test/mcp" } ]
+    ActionAgent.provider_credentials_resolver = ->(_owner, provider) { { access_token: "test-key" } if provider == "anthropic" }
+  end
+
+  def teardown
+    ActionAgent.mcp_catalog = @original_catalog
+    ActionAgent.provider_credentials_resolver = @original_credentials
+  end
+
+  def build_suite(tool_name: "healthcheck", tools: nil, prompts: [ "Check database health" ])
+    @tool_name = tool_name
+    agent = ActionAgent::Agent.create!(
+      name: "Production Health", status: :observed, provider: "anthropic", model: "claude-haiku-4-5",
+      instructions: "Use #{tool_name} to report the host's actual status.", tools: tools || [ tool_name ], mcp_servers: [ "host" ]
+    )
+    evaluation = agent.evaluations.new(name: "Host health", judge_kind: "rules", criteria: [])
+    prompts.each_with_index do |prompt, index|
+      evaluation.scenarios.build(key: "health_#{index}", prompt: prompt, expectations: { "tools" => [ tool_name ] })
+    end
+    evaluation.save!
+    evaluation
+  end
+
+  def run_suite(evaluation)
+    runner = ActionAgent::ScenarioEvaluationRunner.new(evaluation)
+    # This regression scores deterministic tool evidence, not an LLM judge.
+    Resolv.stub(:getaddresses, [ "127.0.0.1" ]) do
+      runner.stub(:evals_judge, nil) { runner.call }
+    end
+  end
+
+  def stub_host(error: false, discovery_status: 200)
+    @mcp_requests = []
+    stub_request(:post, "https://host.test/mcp").to_return do |request|
+      payload = JSON.parse(request.body)
+      @mcp_requests << payload
+      if payload["method"] == "notifications/initialized"
+        next { status: 202, body: "" }
+      end
+      if payload["method"] == "tools/list" && discovery_status != 200
+        next { status: discovery_status, body: "Service unavailable" }
+      end
+
+      result = case payload.fetch("method")
+      when "initialize"
+        { protocolVersion: ActionAgent::MCPClient::PROTOCOL_VERSION, capabilities: { tools: {} }, serverInfo: { name: "host", version: "1" } }
+      when "tools/list"
+        { tools: [ {
+          name: @tool_name, description: "Read actual component health from this host",
+          inputSchema: { type: "object", properties: { component: { type: "string" } }, required: [ "component" ] }
+        } ] }
+      when "tools/call"
+        { isError: error, content: [ { type: "text", text: error ? "Database is unavailable" : "Database is healthy" } ] }
+      else
+        flunk "Unexpected MCP method #{payload['method']}"
+      end
+
+      {
+        status: 200,
+        headers: { "Content-Type" => "application/json", "Mcp-Session-Id" => "health-session" },
+        body: { jsonrpc: "2.0", id: payload.fetch("id"), result: result }.to_json
+      }
+    end
+  end
+
+  def stub_provider(call_tool: true)
+    @provider_requests = []
+    stub_request(:post, "https://api.anthropic.com/v1/messages").to_return do |request|
+      payload = JSON.parse(request.body)
+      @provider_requests << payload
+      has_result = payload.fetch("messages").any? do |message|
+        Array(message["content"]).any? { |content| content.is_a?(Hash) && content["type"] == "tool_result" }
+      end
+      invoke = call_tool && !has_result
+      content = if invoke
+        [ { type: "tool_use", id: "tool_health", name: @tool_name, input: { component: "database" } } ]
+      else
+        [ { type: "text", text: "Healthcheck finished." } ]
+      end
+      {
+        status: 200, headers: { "Content-Type" => "application/json" },
+        body: {
+          id: "msg_health_#{@provider_requests.size}", type: "message", role: "assistant",
+          model: payload.fetch("model"), content: content, stop_reason: invoke ? "tool_use" : "end_turn",
+          stop_sequence: nil, usage: { input_tokens: 20, output_tokens: 10 }
+        }.to_json
+      }
+    end
+  end
+
+  test "an observed scenario calls its host tool and persists the actual execution evidence" do
+    evaluation = build_suite
+    stub_host
+    stub_provider
+
+    run = run_suite(evaluation)
+    result = run.scenario_results.sole
+
+    assert_equal "complete", run.status
+    assert_equal "passed", result.status, result.error_message
+    assert_equal 1.0, result.scores["expected_tools"]
+    assert_equal 1.0, result.scores["tools_succeeded"]
+    assert_equal 2, @provider_requests.size
+    offered = @provider_requests.first.fetch("tools").sole
+    assert_equal "healthcheck", offered["name"]
+    assert_equal [ "component" ], offered.dig("input_schema", "required")
+    call = @mcp_requests.select { |request| request["method"] == "tools/call" }.sole
+    assert_equal({ "name" => "healthcheck", "arguments" => { "component" => "database" } }, call["params"])
+    assert_equal [ "healthcheck" ], result.agent_run.output_metadata["tool_calls"]
+    tool_call = result.tool_calls.sole
+    assert_equal "healthcheck", tool_call["name"]
+    assert_equal({ "component" => "database" }, tool_call["arguments"])
+    assert_equal false, tool_call["error"]
+    assert_includes tool_call["detail"], "Database is healthy"
+    trace = ActionAgent.trace_model.find_by!(trace_id: result.agent_run.trace_id)
+    span = trace.spans.find { |entry| entry.dig("attributes", "tool.name") == "healthcheck" }
+    assert_equal "host", span.dig("attributes", "tool.mcp_server")
+    assert_equal "Database is healthy", span.dig("attributes", "tool.output.result")
+    assert evaluation.agent.reload.observed?
+  end
+
+  test "a host tool named prompt does not overwrite the runtime agent's prompt method" do
+    evaluation = build_suite(tool_name: "prompt")
+    stub_host
+    stub_provider
+
+    result = run_suite(evaluation).scenario_results.sole
+
+    assert_equal "passed", result.status, result.error_message
+    assert_equal "prompt", result.tool_calls.sole["name"]
+    assert_equal "prompt", @provider_requests.first.fetch("tools").sole["name"]
+    call = @mcp_requests.select { |request| request["method"] == "tools/call" }.sole
+    assert_equal "prompt", call.dig("params", "name")
+    assert_equal({ "component" => "database" }, call.dig("params", "arguments"))
+  end
+
+  test "a host tool error is persisted as a tool_error diagnosis" do
+    evaluation = build_suite
+    stub_host(error: true)
+    stub_provider
+
+    result = run_suite(evaluation).scenario_results.sole
+
+    assert_equal "failed", result.status
+    assert_equal "tool_error", result.fault
+    assert_equal true, result.tool_calls.sole["error"]
+    assert_includes result.tool_calls.sole["detail"], "Database is unavailable"
+    assert_includes result.recommendation, "healthcheck"
+  end
+
+  test "a declared host tool omitted by the model is diagnosed as available" do
+    evaluation = build_suite
+    stub_host
+    stub_provider(call_tool: false)
+
+    result = run_suite(evaluation).scenario_results.sole
+
+    assert_equal "expected_tool_not_called", result.fault
+    assert_empty result.diagnosis.dig("evidence", "unavailable")
+    assert_empty @mcp_requests.select { |request| request["method"] == "tools/call" }
+  end
+
+  test "diagnosis uses the live MCP roster for tools named like builder categories" do
+    evaluation = build_suite(tool_name: "memory")
+    stub_host
+    stub_provider(call_tool: false)
+
+    result = run_suite(evaluation).scenario_results.sole
+
+    assert_equal "expected_tool_not_called", result.fault
+    assert_empty result.diagnosis.dig("evidence", "unavailable")
+    assert_equal [ "memory" ], @provider_requests.first.fetch("tools").map { |tool| tool["name"] }
+  end
+
+  test "unresolved declared tools fail every scenario before provider generation" do
+    evaluation = build_suite(tools: [ "missing_healthcheck" ], prompts: [ "Check database health", "Check cache health" ])
+    stub_host
+    stub_provider
+
+    run = run_suite(evaluation)
+
+    assert_equal "complete", run.status
+    assert_equal 2, run.scenario_results.count
+    run.scenario_results.each do |result|
+      assert_equal "errored", result.status
+      assert_equal "run_error", result.fault
+      assert_includes result.error_message, "missing_healthcheck"
+      assert result.agent_run.failed?
+    end
+    assert_empty @provider_requests
+  end
+
+  test "MCP discovery failure remains an actionable per-scenario run error" do
+    evaluation = build_suite(prompts: [ "Check database health", "Check cache health" ])
+    stub_host(discovery_status: 503)
+    stub_provider
+
+    run = run_suite(evaluation)
+
+    assert_equal "complete", run.status
+    assert_equal 2, run.scenario_results.count
+    run.scenario_results.each do |result|
+      assert_equal "errored", result.status
+      assert_equal "run_error", result.fault
+      assert_includes result.error_message, "host"
+      assert_includes result.error_message, "503"
+      assert result.agent_run.failed?
+    end
+    assert_empty @provider_requests
+  end
+end

--- a/docs-tracking/issues/419-host-mcp-execution/branches.md
+++ b/docs-tracking/issues/419-host-mcp-execution/branches.md
@@ -1,0 +1,19 @@
+# Branch: host MCP execution
+
+- Issue: [activeagents/activeagent#419](https://github.com/activeagents/activeagent/issues/419)
+- Branch: `codex/419-host-mcp-execution`
+- Base: `main` at `1ab417d721b1d636144d0e83f38a4f0f48943dd6`
+- Repository: `activeagents/activeagent` (the engine/framework repository).
+- Working checkout: isolated from the user's `activeagents` application checkout.
+
+## Related work
+
+- [#414](https://github.com/activeagents/activeagent/pull/414) remains open:
+  its host evaluation adapter can remain a compatibility path. This change
+  implements native MCP replay on current `main` and does not depend on that PR.
+- [#405](https://github.com/activeagents/activeagent/pull/405) remains open:
+  both changes touch `AgentExecutionService`. Preserve its conversation and
+  `render_ui` behavior when rebasing; dispatch selected MCP bindings before
+  built-ins, and keep tool calls flowing through the service's allowlist.
+- [#415](https://github.com/activeagents/activeagent/pull/415) consumes saved
+  evaluation evidence and needs no integration change here.

--- a/docs-tracking/issues/419-host-mcp-execution/issue.md
+++ b/docs-tracking/issues/419-host-mcp-execution/issue.md
@@ -1,0 +1,57 @@
+The dashboard can already **describe** a host's MCP tools but cannot **call** them, so an evaluation of any agent whose tools come from the host scores near zero and the model answers without them. Closing that gap in the engine also removes the reason a host would write its own evaluation runner.
+
+Supersedes / narrows https://github.com/activeagents/activeagent/issues/418, which asked for a host-registered executor callback. Reading the code, a callback is the wrong shape: the engine already models everything needed.
+
+### What already exists
+
+- `Agent#mcp_servers` — persisted, and the builder writes it
+- `EvaluationToolResolver#configured_entries` — normalises the three stored shapes (bare names, builder hashes, legacy name-keyed Hash)
+- `ToolDiscovery#configured_mcp_servers` — enumerates a server's tools
+- `ActionAgent.mcp_catalog` — host-registered servers with `transport`, `url`, `tool_hints`
+- `PlaywrightMCPClient` — a working Streamable-HTTP MCP client: `initialize` handshake, session id, `call_tool(name, arguments)`
+
+### The gap
+
+`AgentExecutionService#execute_tool` ends at:
+
+```ruby
+else
+  AgentToolbox.call(name, **kwargs)
+end
+```
+
+`mcp_servers` is read for discovery and reporting but never consulted at execution. So a tool the dashboard correctly attributes to a host server is dispatched to the engine's built-in toolbox, which does not have it.
+
+### Consequence, measured
+
+In a Rails host (Sparkle) whose agent declares 14 MCP tools:
+
+```ruby
+agent.tools & ActionAgent::Agent::AVAILABLE_TOOLS  # => []
+```
+
+A scenario asking the agent to run a healthcheck **completed successfully** with `tool_calls: []` and this answer:
+
+> "Running healthcheck… Database connection: Healthy, Cache: Healthy, Search service: Healthy…"
+
+Nothing touched the host. A confidently fabricated answer is worse than an error, and it scores as `expected_tool_not_called`, which reads as an agent-configuration problem rather than an engine limitation.
+
+### Proposal
+
+**1. Dispatch to the agent's MCP servers before falling back to the toolbox.** Generalise `PlaywrightMCPClient` into an MCP client keyed by server url/transport (the Playwright client becomes one configured instance), resolve `name` against the agent's `mcp_servers` via the existing resolver, and call it. Fall back to `AgentToolbox` only when no server claims the tool.
+
+**2. Fail loudly when a declared tool resolves to nothing.** Independent of (1): if an agent declares tools that bind to neither an MCP server nor the toolbox, the run should error rather than let the model answer without them. This alone converts the fabricated healthcheck into an actionable failure.
+
+**3. Drop the observed-agent execution ban once (1) lands.** `Agent#ensure_executable!` refuses `status: :observed`. Its purpose was that an observed agent has nothing to execute — but with host MCP binding, an agent reconstructed from telemetry has exactly what it needs: instructions, model, and declared servers. Evaluating the agent that actually ran in production is the most useful case, and today it is the one that is forbidden.
+
+### Why this matters beyond one host
+
+Without it, every host that wants to evaluate its own agents writes a private runner and threads it into the engine. We are doing that today through `scenario_evaluation_adapter_resolver`, which means customer-specific evaluation code living in a customer's application. With (1)–(3), a host declares `mcp_servers` on an agent and the dashboard runs the catalog itself.
+
+It also makes a **feature matrix** a framework feature rather than a per-host one: one catalog, N agents, pass rate and average tokens per question group. The data is already persisted on `EvaluationScenarioResult` (`status`, `input_tokens`, `output_tokens`, `cost`) joined to the scenario's `group`; only the reporting view is missing.
+
+### Interaction with the open PRs
+
+- **#414** (`codex/evaluation-contract-fixes`) — adds `scenario_evaluation_adapter_resolver`, the host-runtime hook. That hook is what makes host tools reachable *today*, and this proposal is the native replacement for it. Worth landing #414 first and treating the resolver as the compatibility path, not the destination.
+- **#405** (conversation workbench) — touches `AgentExecutionService` heavily, including `execute_tool` and tool-row persistence, and adds the `render_ui` tool through the same dispatch. Whichever lands second will need to rebase onto the other's `execute_tool`; worth sequencing deliberately rather than in parallel.
+- **#415** (dashboard assistant) — reads recorded evaluation results as evidence. Unaffected by the dispatch change, and a beneficiary of the matrix data.

--- a/docs-tracking/issues/419-host-mcp-execution/milestones.md
+++ b/docs-tracking/issues/419-host-mcp-execution/milestones.md
@@ -1,0 +1,48 @@
+# Issue 419 milestones
+
+- [x] Confirm the issue requirements, current main, and related open PRs.
+- [x] Extract a reusable MCP client while retaining the Playwright interface.
+- [x] Reuse configured-server normalization and bind only enabled servers.
+- [x] Offer live schemas and dispatch selected host tools before built-ins.
+- [x] Fail unresolved declarations before provider generation.
+- [x] Enable observed agent execution and evaluation through existing gates.
+- [x] Exercise a native provider/MCP replay and persist its evaluation evidence.
+- [x] Cover tool errors, session handling, config shapes, namespaces, and collisions.
+- [x] Complete final engine, integration, and lint validation.
+- [ ] Publish the branch and open the issue-linked PR.
+
+## Scope decisions
+
+The observed-agent prohibition exists in API controllers on current main,
+not `Agent#ensure_executable!` as described in the issue. Only those execution
+prohibitions are removed. Ownership, execution switch, and quota checks remain.
+
+The feature-matrix reporting view mentioned as a future benefit in the issue
+is outside its three implementation proposals. Existing scenario results
+continue to store tool calls, tokens, cost, and faults.
+
+The generic transport supports HTTP/HTTPS Streamable HTTP, including JSON/SSE
+responses and stateless sessions. It does not launch stdio servers or implement
+OAuth/custom authentication headers. Hosts must provide a reachable endpoint
+compatible with this transport.
+
+Protocol references used during implementation:
+- [MCP Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)
+- [MCP lifecycle](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle)
+
+Test logs are kept in the gitignored `tmp/issue-419/` directory.
+
+## Validation
+
+Ruby 4.0.2, Rails 8.1.3.1, and released SolidAgent 0.2.0:
+
+```sh
+BUNDLE_GEMFILE=gemfiles/rails8.gemfile VCR_RECORD_MODE=none bin/test \
+  actionagent/test/*_test.rb test/integration/solid_agent/*_test.rb
+```
+
+318 tests, 1,441 assertions, zero failures, errors, or skips. MCP and provider
+requests are simulated; no host tools or paid model APIs were called.
+
+Repository-wide RuboCop: 516 files inspected, no offenses. `git diff --check`
+also passed. GitHub CI remains a separate check on the published branch.

--- a/docs-tracking/issues/419-host-mcp-execution/milestones.md
+++ b/docs-tracking/issues/419-host-mcp-execution/milestones.md
@@ -9,7 +9,7 @@
 - [x] Exercise a native provider/MCP replay and persist its evaluation evidence.
 - [x] Cover tool errors, session handling, config shapes, namespaces, and collisions.
 - [x] Complete final engine, integration, and lint validation.
-- [ ] Publish the branch and open the issue-linked PR.
+- [x] Publish the branch and open [PR #421](https://github.com/activeagents/activeagent/pull/421).
 
 ## Scope decisions
 

--- a/docs-tracking/issues/419-host-mcp-execution/pull-request.md
+++ b/docs-tracking/issues/419-host-mcp-execution/pull-request.md
@@ -2,6 +2,8 @@
 
 Closes [#419](https://github.com/activeagents/activeagent/issues/419).
 
+Published PR: [#421 — Execute host MCP tools in dashboard runs and evaluations](https://github.com/activeagents/activeagent/pull/421).
+
 Previously, a dashboard agent declaring only host tools could send the model
 an empty tool roster and record an invented healthcheck as a successful run.
 The engine now resolves every declared tool before generation, obtains MCP
@@ -30,4 +32,5 @@ traces, and evaluation evidence. Native replay requires no host adapter.
 - Native Anthropic replay over simulated HTTP verifies the offered live
   schema, actual MCP call, persisted trace, and saved scenario result.
 
-The published PR URL will be recorded after creation.
+Local implementation review completed with no remaining blocking findings.
+GitHub CI is tracked on the PR; no merge or deployment was requested.

--- a/docs-tracking/issues/419-host-mcp-execution/pull-request.md
+++ b/docs-tracking/issues/419-host-mcp-execution/pull-request.md
@@ -1,0 +1,33 @@
+# Pull request: execute host MCP tools in dashboard runs and evaluations
+
+Closes [#419](https://github.com/activeagents/activeagent/issues/419).
+
+Previously, a dashboard agent declaring only host tools could send the model
+an empty tool roster and record an invented healthcheck as a successful run.
+The engine now resolves every declared tool before generation, obtains MCP
+schemas from enabled servers, and routes their calls through the same session.
+An unbound declaration produces an actionable failed run.
+
+Observed agents can execute and run scenario suites under the existing
+execution, ownership, and quota gates. Tool failures remain visible in events,
+traces, and evaluation evidence. Native replay requires no host adapter.
+
+## Review notes
+
+- MCP bindings take precedence over the toolbox, with no fallback on an MCP error.
+- Discovery never broadens the selected tool roster or enables a catalog server.
+- Runtime tool callbacks avoid defining arbitrary host tool names as agent methods.
+- Exact MCP names also take precedence over matching builder category names.
+- Playwright keeps its singleton and default URL while sharing the generic transport.
+- No frontend, deployment, Terraform, or dependency changes.
+
+## Validation
+
+- Full engine suite plus released SolidAgent integration: 318 tests,
+  1,441 assertions, no failures/errors/skips (Ruby 4.0.2, Rails 8.1.3.1).
+- Repository-wide RuboCop: 516 files, no offenses.
+- `git diff --check` passed.
+- Native Anthropic replay over simulated HTTP verifies the offered live
+  schema, actual MCP call, persisted trace, and saved scenario result.
+
+The published PR URL will be recorded after creation.


### PR DESCRIPTION
Closes #419.

Dashboard runs previously dropped host MCP tools from the model’s tool roster, allowing a healthcheck prompt to succeed without touching the host. This change resolves every declared tool before generation, offers live schemas from enabled MCP servers, and dispatches calls through their MCP session. Unbound tools fail with an actionable error.

- Extract a generic Streamable HTTP client, retaining Playwright compatibility; support HTTPS, JSON/SSE, paginated discovery, optional sessions, and tool-error reporting.
- Reuse configured-server normalization, enforce the selected tool roster, and prefer enabled MCP bindings over built-ins. Keep arbitrary MCP names from overriding runtime agent methods.
- Allow observed agents to run and evaluate under existing ownership, execution, and quota gates. Evaluation diagnosis uses the same resolved tool roster.

Validation: **318 engine and SolidAgent integration tests, 1,441 assertions, zero failures/errors/skips** (Ruby 4.0.2, Rails 8.1.3.1). Includes native Anthropic tool-loop replay against simulated MCP HTTP responses. Repository-wide RuboCop: **516 files, no offenses**. `git diff --check` passes.

Built on current `main`. #414 remains a compatible host-adapter path; #405 overlaps `AgentExecutionService` and will need to preserve MCP precedence and callback dispatch when rebased. Supports Streamable HTTP endpoints; does not launch stdio processes or implement OAuth/custom authentication headers.

Issue, branch, milestones, and PR review notes: `docs-tracking/issues/419-host-mcp-execution/`. Setup example: `actionagent/README.md`.
