### PR TITLE
chore(release): activeagent and actionagent 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-10
+
 ### Added
+
+- **`actionagent`: the dashboard calls a host's MCP tools instead of only
+  describing them.** An agent whose tools come from the host application's own
+  MCP servers could be attributed but not executed: `AgentExecutionService`
+  routed every call through `AgentToolbox`, and `tool_schemas` described only
+  the toolbox's own tools — so a host tool was never offered to the model,
+  which then answered from memory rather than calling it. A scenario asking an
+  agent to run a healthcheck returned a confident summary of services it never
+  contacted. `MCPToolDispatcher` now resolves the servers an agent declares,
+  offers their live `tools/list` schemas alongside the toolbox's, and
+  dispatches a call to the server that serves it. `MCPClient` generalizes the
+  Playwright client into a Streamable HTTP client for any server: TLS,
+  JSON and SSE responses, optional sessions, and stateless servers that answer
+  the handshake with no session id. An observed agent may execute once it names
+  a reachable server, since it carries the instructions, model and servers a
+  run needs. Set `ACTIONAGENT_MCP_ORIGIN` to the origin a host's relative
+  server paths ("/mcp/diagnostic") are served under.
 
 - **`ActiveAgent::Evals::Publisher` delivers a finished report to a
   collector.** A run that already happened — in CI, in a host app's own

--- a/actionagent/lib/action_agent/version.rb
+++ b/actionagent/lib/action_agent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActionAgent
-  VERSION = "1.3.0"
+  VERSION = "1.5.0"
 end

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
Bumps both gems to 1.5.0 and stamps the changelog. Tag `v1.5.0` after this merges to publish — `.github/workflows/release.yml` builds both gems and pushes them via RubyGems trusted publishing (OIDC), so no `gem push` or OTP is needed.

`actionagent` goes 1.3.0 → 1.5.0 to align both gems on one version. The workflow skips a version already on RubyGems, so releasing them together is safe.

### Contents

Everything on `main` since v1.4.0, headlined by https://github.com/activeagents/activeagent/pull/420 — the dashboard now calls a host's MCP tools rather than only describing them (closes https://github.com/activeagents/activeagent/issues/419).

### Verification

Both gems build and contain their entry points (`rake build_all`), and the packaged `actionagent-1.5.0.gem` carries `mcp_client.rb` and `mcp_tool_dispatcher.rb`.

The merged code was exercised end to end against a host application before merge: Clara telemetry recorded a trace with `status: OK`, and an agent run resolved 9 tool schemas from a host MCP server and completed a full round trip (`Tool call: search_providers` → `finish=stop`).

### Known gaps shipping in this release

- https://github.com/activeagents/activeagent/issues/425 — `MCPToolDispatcher#tool_definitions` rescues a failed `tools/list` to `[]` with only a warning, so an agent whose servers are unreachable runs tool-less and the model fabricates results instead of failing.
- https://github.com/activeagents/activeagent/issues/422 — scenario evaluations still run sequentially; Active Job fan-out is planned for 1.6.