### PR TITLE
fix(evals): name the model of a spec hash rather than stringifying it

### DIFF
--- a/lib/active_agent/evals/model_spec.rb
+++ b/lib/active_agent/evals/model_spec.rb
@@ -46,8 +46,22 @@ module ActiveAgent
       # duplicates by label.
       def self.parse_all(values, **options)
         values = values.to_s.split(",") unless values.is_a?(Array)
-        values.map { |value| value.to_s.strip }.reject(&:blank?).uniq.map { |value| parse(value, **options) }
+        values.map { |value| coerce(value) }.reject(&:blank?).uniq.map { |value| parse(value, **options) }
       end
+
+      # The label of one requested model. A caller that round-trips a spec —
+      # the dashboard persists `specs.map(&:to_h)` and hands it back on a
+      # re-run — sends a Hash, whose `to_s` is the inspected Hash and reaches
+      # the provider as the model ID: `{"label" => "openrouter/gpt-4o-mini",
+      # ...} is not a valid model ID`.
+      #
+      # @return [String, nil] nil when the value names no model
+      def self.coerce(value)
+        return value.to_h.stringify_keys.values_at("label", "model").compact.first.to_s.strip if value.respond_to?(:to_h) && !value.is_a?(String)
+
+        value.to_s.strip
+      end
+      private_class_method :coerce
 
       # The provider a bare model name runs under. A rule whose provider the
       # caller does not offer is skipped, so an app without Ollama does not

--- a/test/evals/model_spec_test.rb
+++ b/test/evals/model_spec_test.rb
@@ -58,6 +58,35 @@ class EvalsModelSpecTest < ActiveSupport::TestCase
     assert_equal [ "gpt-5-mini", "qwen3:8b" ], specs.map(&:label)
   end
 
+  # The dashboard persists a run's models as `specs.map(&:to_h)` and hands that
+  # back on a re-run, so parse_all receives Hashes. `to_s` on one is the
+  # inspected Hash, which reached the provider as the model ID and failed every
+  # scenario with "... is not a valid model ID".
+  def test_parse_all_names_the_model_of_a_spec_hash
+    specs = ActiveAgent::Evals::ModelSpec.parse_all(
+      [ { "label" => "openrouter/openai/gpt-4o-mini", "model" => "openai/gpt-4o-mini", "provider" => "openrouter" } ],
+      default_provider: "openai"
+    )
+
+    assert_equal 1, specs.size
+    assert_equal "openrouter", specs.first.provider
+    assert_equal "openai/gpt-4o-mini", specs.first.model
+  end
+
+  def test_parse_all_names_the_model_of_a_symbol_keyed_spec_hash
+    specs = ActiveAgent::Evals::ModelSpec.parse_all(
+      [ { label: "openrouter/openai/gpt-4o-mini", model: "openai/gpt-4o-mini" } ], default_provider: "openai"
+    )
+
+    assert_equal "openai/gpt-4o-mini", specs.first.model
+  end
+
+  def test_parse_all_names_the_model_of_a_spec_hash_without_a_label
+    specs = ActiveAgent::Evals::ModelSpec.parse_all([ { "model" => "gpt-4o-mini" } ], default_provider: "openai")
+
+    assert_equal "gpt-4o-mini", specs.first.model
+  end
+
   def test_a_blank_name_is_rejected
     assert_raises(ArgumentError) { parse("  ") }
   end


### PR DESCRIPTION
A scenario evaluation started from the dashboard failed every scenario with HTTP 400 before reaching the model.

### Root cause

`ModelSpec.parse_all` calls `to_s` on each value:

```ruby
values.map { |value| value.to_s.strip }
```

A `Hash` stringifies to its inspected form, which then travels as the model ID. OpenRouter answers:

```
{"label" => "openrouter/openai/gpt-4o-mini", "model" => "openai/gpt-4o-mini",
 "provider" => "openrouter"} is not a valid model ID
```

This is reachable from the dashboard by design, not by misuse: `ScenarioEvaluationRunner#selection_summary` persists a run's models as `specs.map(&:to_h)`, and re-running that selection hands the hashes straight back to `parse_all`. A caller passing a plain string (`test_execute`) was unaffected, which is why single runs worked while every batch run failed.

### Fix

`parse_all` names the model of a hash — `label` first, then `model` — and leaves strings alone.

### Verification

Against a host application whose agent calls MCP tools, the same three-scenario run before and after:

| | before | after |
|---|---|---|
| errors | 3 × HTTP 400 | **0** |
| tool calls | none | `list_filters`, `search_providers` |
| scores | 0.0 | 0.68 – 0.875 |
| duration | ~1s (failed early) | 2.8 – 4.3s |

The remaining failures are genuine quality results rather than infrastructure.

Three regression tests cover the label-bearing hash, a symbol-keyed hash, and a hash carrying only `model`.