### PR TITLE
Release 1.5.0 back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-10
+
+Releases `activeagent` 1.5.0 and `actionagent` 1.5.0 from one tag.
+
+`actionagent` goes from 1.3.0 to 1.5.0, skipping 1.4: the two gems are
+released together from this repository and from one tag, and carrying one
+version number across both is less confusing than explaining which
+dashboard version pairs with which framework. `actionagent` 1.4 does not
+exist and never will. The engine's floor on the framework
+(`activeagent >= 1.4`) is unchanged and still correct.
+
 ### Added
 
 - **`ActiveAgent::Evals::Publisher` delivers a finished report to a

--- a/actionagent/app/services/action_agent/agent_registrar.rb
+++ b/actionagent/app/services/action_agent/agent_registrar.rb
@@ -10,9 +10,10 @@ module ActionAgent
   # metrics can hang off.
   #
   # Identity is (account, service_name, agent_class, agent_action) — one agent
-  # per action, not per class. Clara.respond (admin assistant, every MCP tool,
-  # ~$0.03/run) and Clara.title (no tools, temperature 0.2, ~$0.0004/run) are
-  # different agents that share a class name because one app method spawns both.
+  # per action, not per class. Assistant.respond (admin assistant, every MCP
+  # tool, ~$0.03/run) and Assistant.title (no tools, temperature 0.2,
+  # ~$0.0004/run) are different agents that share a class name because one app
+  # method spawns both.
   # Collapsing them would blend a $0.03 agent with a $0.0004 one into a single
   # meaningless cost-per-run.
   #
@@ -60,7 +61,7 @@ module ActionAgent
       @trace.agent_action.presence
     end
 
-    # Name carries the action so the two Claras are distinguishable anywhere a
+    # Name carries the action so the two agents are distinguishable anywhere a
     # bare agent name is shown.
     def display_name
       action_name ? "#{agent_class}.#{action_name}" : agent_class
@@ -138,8 +139,8 @@ module ActionAgent
 
     # Config we can only learn by watching: the model actually used, the
     # instructions actually sent (when content capture is on), and the tools
-    # actually called — which is how Clara.respond acquires a tool list while
-    # Clara.title correctly stays empty.
+    # actually called — which is how Assistant.respond acquires a tool list while
+    # Assistant.title correctly stays empty.
     def llm_attribute(key)
       spans.filter_map { |span| span.dig("attributes", key).presence }.first
     end

--- a/actionagent/app/services/action_agent/evaluation_tool_resolver.rb
+++ b/actionagent/app/services/action_agent/evaluation_tool_resolver.rb
@@ -97,7 +97,7 @@ module ActionAgent
     end
 
     # normalized key => the display name a configured hash entry carries
-    # alongside its key ({"key" => "sparkle", "name" => "Sparkle Match"}).
+    # alongside its key ({"key" => "booking", "name" => "Booking Service"}).
     def configured_names
       @configured_names ||= configured_entries.each_with_object({}) do |entry, map|
         next unless entry.respond_to?(:key?)
@@ -111,7 +111,7 @@ module ActionAgent
     end
 
     # bare tool name => server key, from configured entries that list the
-    # tools they serve ({"name" => "sparkle", "tools" => ["search_slots"]}),
+    # tools they serve ({"name" => "booking", "tools" => ["search_slots"]}),
     # in the catalog's own +tool_hints+ spelling or as tool hashes.
     def configured_tools
       @configured_tools ||= configured_entries.each_with_object({}) do |entry, map|

--- a/actionagent/frontend/components/dashboard/InteractionsView.jsx
+++ b/actionagent/frontend/components/dashboard/InteractionsView.jsx
@@ -312,8 +312,8 @@ export default function InteractionsView({ agentId = null, embedded = false }) {
     }
   }, [sortBy]);
 
-  // Group by Agent.action, not by agent class. Clara.respond (admin assistant,
-  // full tool access, ~$0.03/run) and Clara.title (no tools, temperature 0.2,
+  // Group by Agent.action, not by agent class. Assistant.respond (admin assistant,
+  // full tool access, ~$0.03/run) and Assistant.title (no tools, temperature 0.2,
   // ~$0.0004/run) are different agents that share a class name because one app
   // method spawns both; interleaving their streams hides that.
   const agentGroups = useMemo(() => {
@@ -533,7 +533,7 @@ export default function InteractionsView({ agentId = null, embedded = false }) {
         <div className="space-y-8">
           {agentGroups.map((group) => (
           <div key={group.key} className="space-y-4">
-            {/* Agent header — Clara.respond and Clara.title are different
+            {/* Agent header — Assistant.respond and Assistant.title are different
                 agents (different instructions, tools, cost), so their streams
                 are grouped rather than interleaved. */}
             <div className="flex items-baseline justify-between">

--- a/actionagent/lib/action_agent/version.rb
+++ b/actionagent/lib/action_agent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActionAgent
-  VERSION = "1.3.0"
+  VERSION = "1.5.0"
 end

--- a/actionagent/test/evaluation_run_test.rb
+++ b/actionagent/test/evaluation_run_test.rb
@@ -184,8 +184,8 @@ class ActionAgentEvaluationToolResolverTest < ActiveSupport::TestCase
 
   test "a namespaced server nothing else knows is named, with no status" do
     assert_equal(
-      { "key" => "sparkle-match", "name" => "sparkle-match", "status" => nil },
-      resolver.call("mcp__sparkle-match__search_slots")
+      { "key" => "booking-match", "name" => "booking-match", "status" => nil },
+      resolver.call("mcp__booking-match__search_slots")
     )
   end
 
@@ -194,9 +194,9 @@ class ActionAgentEvaluationToolResolverTest < ActiveSupport::TestCase
   end
 
   test "a host-registered catalog server is available for the tools it hints" do
-    ActionAgent.mcp_catalog = [ { key: "sparkle-match", name: "Sparkle Match", tool_hints: %w[search_slots] } ]
+    ActionAgent.mcp_catalog = [ { key: "booking-match", name: "Booking Match", tool_hints: %w[search_slots] } ]
 
-    assert_equal({ "key" => "sparkle-match", "name" => "Sparkle Match", "status" => "available" }, resolver.call("search_slots"))
+    assert_equal({ "key" => "booking-match", "name" => "Booking Match", "status" => "available" }, resolver.call("search_slots"))
   ensure
     ActionAgent.mcp_catalog = []
   end
@@ -212,23 +212,23 @@ class ActionAgentEvaluationToolResolverTest < ActiveSupport::TestCase
     agent = ActionAgent::Agent.new(
       name: "Assistant",
       mcp_servers: [ {
-        "key" => "sparkle", "name" => "Sparkle Match", "url" => "https://sparkle.test/mcp",
+        "key" => "booking", "name" => "Booking Match", "url" => "https://booking.test/mcp",
         "tools" => [ "search_slots", { "name" => "book_appointment" } ]
       } ]
     )
 
-    assert_equal({ "key" => "sparkle", "name" => "Sparkle Match", "status" => "enabled" }, resolver(agent).call("search_slots"))
-    assert_equal "sparkle", resolver(agent).call("book_appointment")["key"]
+    assert_equal({ "key" => "booking", "name" => "Booking Match", "status" => "enabled" }, resolver(agent).call("search_slots"))
+    assert_equal "booking", resolver(agent).call("book_appointment")["key"]
   end
 
   test "the older hash-keyed configuration is read the same way" do
     agent = ActionAgent::Agent.new(
       name: "Assistant",
-      mcp_servers: { "playwright" => { "command" => "npx @playwright/mcp@latest" }, "sparkle" => { "tools" => [ "search_slots" ] } }
+      mcp_servers: { "playwright" => { "command" => "npx @playwright/mcp@latest" }, "booking" => { "tools" => [ "search_slots" ] } }
     )
 
     assert_equal "enabled", resolver(agent).call("mcp__playwright__browser_click")["status"]
-    assert_equal({ "key" => "sparkle", "name" => "sparkle", "status" => "enabled" }, resolver(agent).call("search_slots"))
+    assert_equal({ "key" => "booking", "name" => "booking", "status" => "enabled" }, resolver(agent).call("search_slots"))
   end
 
   test "an agent-defined tool, a blank name and malformed entries resolve to nothing" do
@@ -263,7 +263,7 @@ class ActionAgentEvaluationRunReportTest < ActiveSupport::TestCase
       fault: "expected_tool_not_called", recommendation: "Enable the tool and re-run.",
       diagnosis: {
         "fault" => "expected_tool_not_called",
-        "summary" => "Expected browser_navigate to be called; clara called nothing.",
+        "summary" => "Expected browser_navigate to be called; assistant called nothing.",
         "recommendation" => "Enable the tool and re-run.",
         "evidence" => { "expected" => [ "browser_navigate" ], "called" => [], "unavailable" => [ "browser_navigate" ] }
       }
@@ -272,19 +272,19 @@ class ActionAgentEvaluationRunReportTest < ActiveSupport::TestCase
   end
 
   test "the report carries the agent, its tool resolver and mount-relative links" do
-    agent = ActionAgent::Agent.create!(name: "Clara", provider: "mock", model: "mock-model", mcp_servers: [ "playwright" ])
+    agent = ActionAgent::Agent.create!(name: "Assistant", provider: "mock", model: "mock-model", mcp_servers: [ "playwright" ])
     run = create_run(agent)
 
     report = run.to_report
 
-    assert_equal "Clara", report.agent_name
+    assert_equal "Assistant", report.agent_name
     assert_kind_of ActionAgent::EvaluationToolResolver, report.tool_resolver
     assert_equal({ "mcp" => "/mcp/%{key}", "tools" => "/tools", "instructions" => "/agents/#{agent.id}/edit" }, report.links)
-    assert_equal "Clara", report.metadata["agent"]
+    assert_equal "Assistant", report.metadata["agent"]
   end
 
   test "fix_items delegates to the report with the agent's servers resolved" do
-    agent = ActionAgent::Agent.create!(name: "Clara", provider: "mock", model: "mock-model", mcp_servers: [ "playwright" ])
+    agent = ActionAgent::Agent.create!(name: "Assistant", provider: "mock", model: "mock-model", mcp_servers: [ "playwright" ])
     run = create_run(agent)
 
     item = run.fix_items.first
@@ -295,7 +295,7 @@ class ActionAgentEvaluationRunReportTest < ActiveSupport::TestCase
   end
 
   test "report_links prefixes the dashboard mount for the standalone report page" do
-    agent = ActionAgent::Agent.create!(name: "Clara", provider: "mock", model: "mock-model")
+    agent = ActionAgent::Agent.create!(name: "Assistant", provider: "mock", model: "mock-model")
     run = create_run(agent)
 
     links = run.report_links(mount: "/activeagents/")
@@ -303,12 +303,12 @@ class ActionAgentEvaluationRunReportTest < ActiveSupport::TestCase
     assert_equal "/activeagents/mcp/%{key}", links["mcp"]
     assert_equal "/activeagents/tools", links["tools"]
     assert_equal "/activeagents/agents/#{agent.id}/edit", links["instructions"]
-    assert_equal "Enable Playwright for Clara", run.fix_items(links: links).first.dig("action", "label")
+    assert_equal "Enable Playwright for Assistant", run.fix_items(links: links).first.dig("action", "label")
     assert_equal "/activeagents/mcp/playwright", run.fix_items(links: links).first.dig("action", "path")
   end
 
   test "a run without scenario results has no fix items" do
-    agent = ActionAgent::Agent.create!(name: "Clara", provider: "mock", model: "mock-model")
+    agent = ActionAgent::Agent.create!(name: "Assistant", provider: "mock", model: "mock-model")
     evaluation = agent.evaluations.create!(
       name: "Sampling", judge_kind: "rules",
       criteria: [ { "key" => "response_present", "type" => "response_present", "config" => {} } ]
@@ -341,7 +341,7 @@ class ActionAgentEvaluationRunVerdictTest < ActiveSupport::TestCase
   # ollama/qwen3:8b: a report that still names gpt-5-mini can only have read
   # the verdict the run recorded.
   def create_comparison_run(verdict: nil, judge_model: nil, models: [ HOSTED, LOCAL ])
-    agent = ActionAgent::Agent.create!(name: "Clara", provider: "openai", model: "gpt-5-mini")
+    agent = ActionAgent::Agent.create!(name: "Assistant", provider: "openai", model: "gpt-5-mini")
     evaluation = agent.evaluations.new(name: "Bake-off", judge_kind: "rules", judge_model: judge_model, criteria: [])
     evaluation.scenarios.build(key: "find_slots", prompt: "Find the next slot", position: 0)
     evaluation.scenarios.build(key: "cancel_slot", prompt: "Cancel it", position: 1)

--- a/actionagent/test/mcp_tool_dispatcher_test.rb
+++ b/actionagent/test/mcp_tool_dispatcher_test.rb
@@ -76,7 +76,7 @@ class MCPToolDispatcherTest < ActiveSupport::TestCase
   test "an unreachable server returns a scoreable error rather than raising" do
     dispatcher = dispatcher_with_client(StubClient.new(raises: "boom"))
 
-    result = dispatcher.call("count_records", { "model" => "Physician" })
+    result = dispatcher.call("count_records", { "model" => "Provider" })
 
     assert_match(/count_records failed: boom/, result[:error])
   end

--- a/actionagent/test/scenario_evaluation_runner_test.rb
+++ b/actionagent/test/scenario_evaluation_runner_test.rb
@@ -162,7 +162,7 @@ class ActionAgentScenarioEvaluationRunnerTest < ActiveSupport::TestCase
       status: :complete, trace_id: SecureRandom.uuid, input_prompt: "x", output: "Found 3 providers.",
       duration_ms: 120, input_tokens: 10, output_tokens: 5,
       logs: [
-        { "eid" => "1-1", "kind" => "tool", "label" => "find_records", "status" => "started", "detail" => { "model" => "Physician" }.to_json },
+        { "eid" => "1-1", "kind" => "tool", "label" => "find_records", "status" => "started", "detail" => { "model" => "Provider" }.to_json },
         { "eid" => "1-1", "kind" => "tool", "label" => "find_records", "status" => "done", "duration_ms" => 40, "detail" => "3 rows" }
       ]
     )
@@ -172,7 +172,7 @@ class ActionAgentScenarioEvaluationRunnerTest < ActiveSupport::TestCase
     result = run.scenario_results.first
 
     assert_equal "passed", result.status
-    assert_equal [ { "name" => "find_records", "arguments" => { "model" => "Physician" }, "error" => false, "detail" => "3 rows", "duration_ms" => 40 } ],
+    assert_equal [ { "name" => "find_records", "arguments" => { "model" => "Provider" }, "error" => false, "detail" => "3 rows", "duration_ms" => 40 } ],
       result.tool_calls
     assert_equal 1.0, result.scores["expected_tools"]
     assert_equal 1.0, result.scores["tools_succeeded"]

--- a/actionagent/test/scenario_evaluations_api_test.rb
+++ b/actionagent/test/scenario_evaluations_api_test.rb
@@ -395,18 +395,18 @@ class ActionAgentScenarioEvaluationsApiTest < ActionDispatch::IntegrationTest
     agent = create_agent
     evaluation = agent.evaluations.new(name: "Tool coverage", judge_kind: "rules", criteria: [])
     scenario = evaluation.scenarios.build(
-      key: "sync", prompt: "Is sync healthy?", position: 0, expectations: { "tools" => [ "mcp__sparkle__sync_status" ] }
+      key: "sync", prompt: "Is sync healthy?", position: 0, expectations: { "tools" => [ "mcp__booking__sync_status" ] }
     )
     evaluation.save!
     run = evaluation.evaluation_runs.create!(status: :complete, completed_at: Time.current)
     run.scenario_results.create!(
       scenario: scenario, model: "mock-model", provider: "mock", status: :failed, score: 0.5, fault: "tool_error",
-      tool_calls: [ { "name" => "mcp__sparkle__sync_status", "error" => true, "detail" => "no Physician with id=0" } ],
+      tool_calls: [ { "name" => "mcp__booking__sync_status", "error" => true, "detail" => "no Provider with id=0" } ],
       recommendation: "Fix the failing tool before judging the answer.",
       diagnosis: {
-        "fault" => "tool_error", "summary" => "Tool mcp__sparkle__sync_status returned an error while answering.",
+        "fault" => "tool_error", "summary" => "Tool mcp__booking__sync_status returned an error while answering.",
         "recommendation" => "Fix the failing tool before judging the answer.",
-        "evidence" => { "tools" => [ "mcp__sparkle__sync_status" ], "detail" => "no Physician with id=0" }
+        "evidence" => { "tools" => [ "mcp__booking__sync_status" ], "detail" => "no Provider with id=0" }
       }
     )
 
@@ -416,8 +416,8 @@ class ActionAgentScenarioEvaluationsApiTest < ActionDispatch::IntegrationTest
     item = JSON.parse(response.body).dig("run", "fix_items").first
     assert_equal "failing tools", item["tools_label"]
     assert_equal(
-      [ { "name" => "mcp__sparkle__sync_status", "note" => "no Physician with id=0",
-          "server" => { "key" => "sparkle", "name" => "sparkle", "status" => "unknown" } } ],
+      [ { "name" => "mcp__booking__sync_status", "note" => "no Provider with id=0",
+          "server" => { "key" => "booking", "name" => "booking", "status" => "unknown" } } ],
       item["tools"]
     )
     assert_nil item["server"]

--- a/docs/framework/self-hosted-observability.md
+++ b/docs/framework/self-hosted-observability.md
@@ -102,15 +102,15 @@ to the full URL, as shown below, and `resolved_endpoint` returns that.)
 # A path on your main app:
 mount ActionAgent::Engine => "/activeagents"
 
-# Or the root of a dedicated subdomain, e.g. activeagents.combinaut.com:
+# Or the root of a dedicated subdomain, e.g. activeagents.example.com:
 constraints subdomain: "activeagents" do
   mount ActionAgent::Engine => "/", as: :active_agent_subdomain
 end
 ```
 
 With the subdomain mount, the dashboard lives at
-`https://activeagents.combinaut.com/` and remote apps post traces to
-`https://activeagents.combinaut.com/api/traces`.
+`https://activeagents.example.com/` and remote apps post traces to
+`https://activeagents.example.com/api/traces`.
 
 ## Authentication (required in production)
 
@@ -164,7 +164,7 @@ mount:
 production:
   telemetry:
     enabled: true
-    endpoint: https://activeagents.combinaut.com/api/traces
+    endpoint: https://activeagents.example.com/api/traces
     api_key: <%= Rails.application.credentials.dig(:active_agent, :ingest_api_key) %>
 ```
 
@@ -205,7 +205,7 @@ gem "activeagents-telemetry-ruby_llm"
 ```ruby
 # config/initializers/ruby_llm_telemetry.rb
 ActiveAgents::Telemetry::RubyLLM.subscribe!(
-  endpoint: "https://activeagents.combinaut.com/api/traces",
+  endpoint: "https://activeagents.example.com/api/traces",
   api_key: Rails.application.credentials.dig(:active_agent, :ingest_api_key),
   service_name: "billing-app"
 )

--- a/docs/work/release-1.5.0/branch.md
+++ b/docs/work/release-1.5.0/branch.md
@@ -1,0 +1,36 @@
+# Release 1.5.0 branch
+
+- Branch: `release/1.5.0`
+- Base: main commit `cd65327f`
+- Tag: `v1.5.0`
+- Ships: `activeagent` 1.5.0 and `actionagent` 1.5.0 from one tag
+
+## Commits
+
+| Commit | Purpose |
+|--------|---------|
+| `3c697784` | Cherry-picked client-name scrub (comments and docs) |
+| `68b8312d` | Completes the scrub across evals code and test fixtures |
+| `6680a46d` | Version bumps and the dated changelog heading |
+
+## Version jump
+
+`actionagent` goes 1.3.0 -> 1.5.0, skipping 1.4. Both gems are released
+together from this repository and from one tag, so carrying one version
+number across both is less confusing than tracking which dashboard version
+pairs with which framework. `actionagent` 1.4 does not exist. The engine's
+floor on the framework (`activeagent >= 1.4`) is unchanged and still
+correct: 1.5.0 satisfies it.
+
+`activeagent` 1.4.0 -> 1.5.0 is a minor, not a patch, because it adds
+`Evals::Publisher`, the runner's `around_evaluation:` and
+`require_judge_scores:` hooks, and grouped YAML/JSON suite import.
+
+## Artifacts
+
+Built to `pkg/`, not yet pushed:
+
+- `pkg/activeagent-1.5.0.gem` (205 KB, 189 files)
+- `pkg/actionagent-1.5.0.gem` (505 KB)
+
+Publish `activeagent` first; `actionagent` depends on it.

--- a/docs/work/release-1.5.0/validation.md
+++ b/docs/work/release-1.5.0/validation.md
@@ -1,0 +1,57 @@
+# Release 1.5.0 validation
+
+## Test suite
+
+Run as CI runs it, via `bin/test` against `gemfiles/rails8.gemfile`:
+
+```
+1842 runs, 5846 assertions, 1 failures, 42 errors, 42 skips
+```
+
+The 1 failure and 42 errors are **pre-existing and unrelated to this
+release**. This was established by stashing the release changes and running
+the same suite on the untouched base commit, which produced an identical
+count. They are concentrated in the OpenRouter and OpenAI integration tests
+(VCR cassette and API-client territory) plus `RunnerWorkbenchTest`; nothing
+in the evals paths this release touches.
+
+## Lint
+
+`bin/rubocop` — 530 files inspected, no offenses.
+
+## Frontend
+
+`npm test` in `actionagent/frontend` — 8 tests, 8 pass.
+
+The committed dashboard assets in `actionagent/app/assets/builds/` were
+rebuilt from source (`npm ci && npm run build`) and came out byte-identical
+to what is committed, so the gem ships a dashboard matching its sources.
+
+## Gem contents
+
+Both archives were unpacked and checked for the files the Rakefile's
+`build_all` guards on — the failure mode being a gem that installs and
+resolves but dies on `require`:
+
+- `activeagent`: `lib/active_agent.rb`
+- `actionagent`: `lib/action_agent.rb`, `config/routes.rb`,
+  `app/assets/builds/action_agent.js`, `app/assets/builds/action_agent.css`
+
+`actionagent` contains no `lib/active_agent*` — the gemspec's `Dir.chdir`
+guard against sweeping up the framework tree held.
+
+Resolution check: `actionagent` 1.5.0 requires `activeagent >= 1.4, < 2`,
+satisfied by 1.5.0. Both declare `required_ruby_version >= 3.2.0`.
+
+## Environment notes
+
+Two local-only obstacles, neither affecting the release:
+
+- The dummy app's `config/master.key` did not decrypt its
+  `credentials.yml.enc`. CI supplies `RAILS_MASTER_KEY` as a secret. A
+  throwaway pair was generated to boot the suite and the committed files
+  were restored afterwards — verified by checksum.
+- The root `Gemfile` bundle lacks `sqlite3` for the local Ruby 4.0.6, so
+  the suite must be run with `BUNDLE_GEMFILE` pointed at
+  `gemfiles/rails8.gemfile` (an absolute path — `bin/test` sets it with
+  `||=`, and the Rakefile's `chdir` breaks a relative one).

--- a/lib/active_agent/evals/report_html.rb
+++ b/lib/active_agent/evals/report_html.rb
@@ -308,8 +308,8 @@ module ActiveAgent
         %(<div class="tools"><span class="micro sm">#{h(item['tools_label'])}</span><div class="list">#{chips.join}</div></div>)
       end
 
-      # "available · not enabled for Clara", "unknown · not enabled for
-      # Clara" — every status but "enabled" leads with the status word, the
+      # "available · not enabled for Assistant", "unknown · not enabled for
+      # Assistant" — every status but "enabled" leads with the status word, the
       # way the dashboard's fix list reads it.
       def html_fix_server(server)
         badge =

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/test/evals/diagnosis_test.rb
+++ b/test/evals/diagnosis_test.rb
@@ -37,7 +37,7 @@ class EvalsDiagnosisTest < ActiveSupport::TestCase
     result = diagnose(
       scenario: scenario(contains: [ "Alice" ]),
       replay: replay(answer: "I could not look that up.",
-                     tool_calls: [ { "name" => "find_records", "error" => true, "detail" => "timeout", "arguments" => { "model" => "Physician" } } ]),
+                     tool_calls: [ { "name" => "find_records", "error" => true, "detail" => "timeout", "arguments" => { "model" => "Provider" } } ]),
       score: 0.2
     )
 
@@ -61,7 +61,7 @@ class EvalsDiagnosisTest < ActiveSupport::TestCase
   def test_a_negative_result_is_not_a_missing_capability
     result = diagnose(
       scenario: scenario,
-      replay: replay(answer: "I checked the physician table and can't find any providers without a license on file; all 15,043 have one.")
+      replay: replay(answer: "I checked the provider table and can't find any providers without a license on file; all 15,043 have one.")
     )
 
     assert_nil result

--- a/test/evals/report_test.rb
+++ b/test/evals/report_test.rb
@@ -13,9 +13,9 @@ class EvalsReportTest < ActiveSupport::TestCase
   AVAILABLE = %w[find_records healthcheck sync_status].freeze
   LINKS = { "mcp" => "/activeagents/mcp/%{key}", "tools" => "/activeagents/tools", "instructions" => "/activeagents/agents/1/edit" }.freeze
   SERVERS = {
-    "sync_status" => { "key" => "sparkle_diagnostic", "name" => "Sparkle Diagnostic", "status" => "enabled" },
-    "search_slots" => { "key" => "sparkle_match", "name" => "Sparkle Match", "status" => "available" },
-    "book_slot" => { "key" => "sparkle_match", "name" => "Sparkle Match", "status" => "available" }
+    "sync_status" => { "key" => "booking_diagnostic", "name" => "Booking Diagnostic", "status" => "enabled" },
+    "search_slots" => { "key" => "booking_match", "name" => "Booking Match", "status" => "available" },
+    "book_slot" => { "key" => "booking_match", "name" => "Booking Match", "status" => "available" }
   }.freeze
 
   def models
@@ -55,7 +55,7 @@ class EvalsReportTest < ActiveSupport::TestCase
     sync = scenario("s_sync", "Is content sync healthy?", group: "diag", tools: [ "sync_status" ])
     slots = scenario("s_slots", "Find the next available <b>slots</b> for a dermatologist", group: "match", tools: [ "search_slots" ])
     blame = scenario("s_blame", "Who changed the biography?", group: "blame")
-    long_error = "no Physician with id=0 — the record was deleted before the tool ran, try again with a valid id"
+    long_error = "no Provider with id=0 — the record was deleted before the tool ran, try again with a valid id"
 
     [
       result(health, gpt, replay(answer: "All healthy.", tool_calls: [ { "name" => "healthcheck" } ], duration_ms: 2_500, input_tokens: 80, output_tokens: 9, cost: 0.0012)),
@@ -76,7 +76,7 @@ class EvalsReportTest < ActiveSupport::TestCase
   end
 
   def report(**options)
-    Report.new(results: results, models: models, metadata: { "evaluation" => "Sparkle suite", "run" => 3 }, **options)
+    Report.new(results: results, models: models, metadata: { "evaluation" => "Booking suite", "run" => 3 }, **options)
   end
 
   # --- fix items -------------------------------------------------------------
@@ -143,16 +143,16 @@ class EvalsReportTest < ActiveSupport::TestCase
   end
 
   def test_a_tool_resolver_attaches_servers_and_links_fill_the_action_paths
-    items = report(tool_resolver: resolver, agent_name: "Clara", links: LINKS).fix_items
+    items = report(tool_resolver: resolver, agent_name: "Assistant", links: LINKS).fix_items
     by_fault = items.to_h { |item| [ item["fault"], item ] }
 
     missing = by_fault["expected_tool_not_called"]
-    assert_equal({ "key" => "sparkle_match", "name" => "Sparkle Match", "status" => "available" }, missing["server"])
-    assert_equal "Sparkle Match", missing["tools"].first["note"], "a missing tool's note is its server"
-    assert_equal({ "label" => "Enable Sparkle Match for Clara", "hint" => "MCP Services ->", "path" => "/activeagents/mcp/sparkle_match" }, missing["action"])
+    assert_equal({ "key" => "booking_match", "name" => "Booking Match", "status" => "available" }, missing["server"])
+    assert_equal "Booking Match", missing["tools"].first["note"], "a missing tool's note is its server"
+    assert_equal({ "label" => "Enable Booking Match for Assistant", "hint" => "MCP Services ->", "path" => "/activeagents/mcp/booking_match" }, missing["action"])
 
     failing = by_fault["tool_error"]
-    assert_equal "sparkle_diagnostic", failing["tools"].first.dig("server", "key")
+    assert_equal "booking_diagnostic", failing["tools"].first.dig("server", "key")
     assert_equal "/activeagents/tools", failing["action"]["path"]
     assert_nil failing["server"], "only missing tools resolve to a shared server"
 
@@ -161,7 +161,7 @@ class EvalsReportTest < ActiveSupport::TestCase
   end
 
   def test_missing_tools_on_an_enabled_server_or_across_servers_fall_back_to_the_tools_page
-    enabled = ->(_name) { { "key" => "sparkle_match", "name" => "Sparkle Match", "status" => "enabled" } }
+    enabled = ->(_name) { { "key" => "booking_match", "name" => "Booking Match", "status" => "enabled" } }
     item = report(tool_resolver: enabled, links: LINKS).fix_items.first
 
     assert_equal "enabled", item.dig("server", "status")
@@ -241,7 +241,7 @@ class EvalsReportTest < ActiveSupport::TestCase
   end
 
   def test_html_renders_fix_cards_with_tools_server_note_and_actions
-    html = report(tool_resolver: resolver, agent_name: "Clara", links: LINKS).to_html
+    html = report(tool_resolver: resolver, agent_name: "Assistant", links: LINKS).to_html
 
     assert_includes html, "What to fix"
     assert_includes html, "5 items · 6 faults across 4 scenarios"
@@ -252,10 +252,10 @@ class EvalsReportTest < ActiveSupport::TestCase
     assert_includes html, "3 scenarios · gpt-5-mini"
     assert_includes html, "s_slots · judge suggestion"
     assert_includes html, "missing tools"
-    assert_includes html, %(<b>search_slots</b><span class="note">Sparkle Match</span>)
-    assert_includes html, %(<span>served by</span><b>Sparkle Match</b><span class="badge warning xs">available · not enabled for Clara</span>)
+    assert_includes html, %(<b>search_slots</b><span class="note">Booking Match</span>)
+    assert_includes html, %(<span>served by</span><b>Booking Match</b><span class="badge warning xs">available · not enabled for Assistant</span>)
     assert_includes html, "s_jobs is the exception"
-    assert_includes html, %(<a class="btn" target="_top" href="/activeagents/mcp/sparkle_match">Enable Sparkle Match for Clara</a><span class="hint">MCP Services -&gt;</span>),
+    assert_includes html, %(<a class="btn" target="_top" href="/activeagents/mcp/booking_match">Enable Booking Match for Assistant</a><span class="hint">MCP Services -&gt;</span>),
                     "the action leaves the dashboard's report iframe rather than nesting the dashboard in it"
     assert_includes html, "“Use search_slots for appointment questions.”"
     assert_not_includes html, "expected_tool_not_called"
@@ -291,7 +291,7 @@ class EvalsReportTest < ActiveSupport::TestCase
     assert_includes html, "<footer>"
     assert_includes html, "judge rules"
     assert_includes html, "criteria response present"
-    assert_includes html, "evaluation Sparkle suite"
+    assert_includes html, "evaluation Booking suite"
   end
 
   def test_html_escapes_prompts_answers_tool_names_and_metadata

--- a/test/evals/runner_test.rb
+++ b/test/evals/runner_test.rb
@@ -188,7 +188,7 @@ class EvalsRunnerTest < ActiveSupport::TestCase
   def replay_agent(scenario, spec)
     return Replay.new(answer: "I don't have access to change history.", duration_ms: 100) if scenario.group == "blame" && spec.provider == "ollama"
 
-    calls = scenario.prompt.include?("license") && spec.provider == "openai" ? [ { "name" => "find_records", "arguments" => { "model" => "Physician" } } ] : []
+    calls = scenario.prompt.include?("license") && spec.provider == "openai" ? [ { "name" => "find_records", "arguments" => { "model" => "Provider" } } ] : []
     Replay.new(answer: "#{spec.model} says: 12 providers match.", tool_calls: calls, duration_ms: 250, input_tokens: 10, output_tokens: 5, cost: 0.001)
   end
 

--- a/test/evals/scenario_parser_test.rb
+++ b/test/evals/scenario_parser_test.rb
@@ -81,7 +81,7 @@ class EvalsScenarioParserTest < ActiveSupport::TestCase
   end
 
   def test_a_backticked_message_keeps_the_rest_of_the_line_as_notes
-    scenarios = parse("3. `Show me all providers with no license on file` — ✏️ reworded: 1,060 of 15,043 physicians have no license row")
+    scenarios = parse("3. `Show me all providers with no license on file` — ✏️ reworded: 1,060 of 15,043 providers have no license row")
 
     assert_equal "Show me all providers with no license on file", scenarios.first["prompt"]
     assert_match(/reworded/, scenarios.first["notes"])


### PR DESCRIPTION
Brings the published 1.5.0 release back to `main`.

`activeagent` 1.5.0 and `actionagent` 1.5.0 are already on RubyGems, but `main` still declares `VERSION = "1.4.0"` and the `v1.5.0` tag is not reachable from `main`. Every prior release tag (`v1.4.0`) is reachable, so this is the outlier.

Merging restores both invariants at once — the version constant and tag reachability — without rewriting the tag.

### Commits

- `3c697784` chore: remove client names from comments and docs
- `68b8312d` chore: finish scrubbing client names from evals code and fixtures
- `6680a46d` Release activeagent 1.5.0 and actionagent 1.5.0
- `cb1eb363` docs: record the 1.5.0 release branch and its validation

Merges with no conflicts (verified with `git merge-tree`).

### Note on #370

PR #370 (`chore/remove-client-references`) carries an earlier pass of the same client-name scrubbing. `3c697784` here supersedes it, so #370 should be closed or rebased once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01He34kWksjpqPPDpCCqJq2C