### PR TITLE
Surface MCP tool-discovery failures instead of running tool-less and silent

### DIFF
--- a/actionagent/app/services/action_agent/mcp_tool_dispatcher.rb
+++ b/actionagent/app/services/action_agent/mcp_tool_dispatcher.rb
@@ -57,7 +57,15 @@ module ActionAgent
     # contributes nothing rather than failing the run — the tools it serves
     # then simply are not offered, and a scenario expecting them fails with a
     # fault naming them.
+    #
+    # A server that fails discovery also records why, in +discovery_errors+.
+    # Contributing nothing keeps the run alive, but silence is indistinguishable
+    # from a server that legitimately serves no tools — and an agent offered no
+    # tools answers from the model alone, which reads as a confident, fabricated
+    # result rather than a transport failure (#425).
     def tool_definitions
+      @discovery_errors = {}
+
       resolver.declared_server_keys.flat_map do |key|
         entry = MCPCatalog.find(key)
         next [] unless entry && entry[:transport].to_s.in?(HTTP_TRANSPORTS) && entry[:url].present?
@@ -66,9 +74,33 @@ module ActionAgent
           client_for(entry).list_tools
         rescue MCPClient::Error => e
           Rails.logger.warn("[MCPToolDispatcher] #{key} tools/list failed: #{e.message}")
+          @discovery_errors[key] =
+            "Cannot load tools from MCP server '#{key}' (#{entry[:url]}): #{e.message}. " \
+            "Check its URL, transport and credentials."
           []
         end
       end
+    end
+
+    # Why each declared server contributed no tools, keyed by server. Empty
+    # until +tool_definitions+ has run, and empty after a run where every
+    # declared server answered.
+    #
+    # @return [Hash{String => String}]
+    def discovery_errors
+      @discovery_errors ||= {}
+    end
+
+    # Whether every server the agent declares failed discovery. The tool-less
+    # execution that follows cannot produce a meaningful result, so a caller
+    # can fail loudly instead of scoring an answer the model invented.
+    def all_servers_failed?
+      keys = resolver.declared_server_keys.select do |key|
+        entry = MCPCatalog.find(key)
+        entry && entry[:transport].to_s.in?(HTTP_TRANSPORTS) && entry[:url].present?
+      end
+
+      keys.any? && keys.all? { |key| discovery_errors.key?(key) }
     end
 
     private

--- a/actionagent/app/services/action_agent/scenario_evaluation_runner.rb
+++ b/actionagent/app/services/action_agent/scenario_evaluation_runner.rb
@@ -80,6 +80,7 @@ module ActionAgent
         scores: scores_for(report, run),
         samples_evaluated: report.results.size,
         samples_passed: report.results.count(&:passed?),
+        error_message: discovery_warning,
         completed_at: Time.current
       )
       run
@@ -240,10 +241,48 @@ module ActionAgent
       end
     end
 
+    # Every tool the agent could actually call, for the diagnosis roster: the
+    # engine's own toolbox plus whatever its MCP servers serve.
+    #
+    # Listing only the toolbox understated the roster, so a diagnosis could
+    # report "none of the available tools covers this task" while naming a list
+    # the agent's MCP tools were missing from.
     def tool_roster
-      @tool_roster ||= AgentToolbox.definitions_for(@evaluation.agent.tools).to_h do |definition|
-        [ definition[:name].to_s, definition[:description].to_s ]
+      @tool_roster ||= begin
+        definitions = mcp_dispatcher.tool_definitions +
+          AgentToolbox.definitions_for(@evaluation.agent.tools)
+
+        definitions.to_h { |definition| [ definition[:name].to_s, definition[:description].to_s ] }
       end
+    end
+
+    # Discovery failures from the roster above, keyed by server. Reading them
+    # requires tool_definitions to have run, which tool_roster does.
+    def mcp_discovery_errors
+      tool_roster
+      mcp_dispatcher.discovery_errors
+    end
+
+    def mcp_dispatcher
+      @mcp_dispatcher ||= MCPToolDispatcher.new(@evaluation.agent)
+    end
+
+    # A run whose every declared MCP server failed discovery scored an agent
+    # that had no tools to call. The scores are real but meaningless — the
+    # model answered from its own weights — so the run says so rather than
+    # leaving the cause in a log line (#425).
+    def discovery_warning
+      errors = mcp_discovery_errors
+      return nil if errors.empty?
+
+      prefix = if mcp_dispatcher.all_servers_failed?
+        "Every MCP server this agent declares failed tool discovery, so it ran with no MCP tools " \
+        "and any specifics in its answers are unverified."
+      else
+        "Some of this agent's MCP servers failed tool discovery, so part of its toolset was unavailable."
+      end
+
+      "#{prefix} #{errors.values.join(' ')}"
     end
 
     # The judge the evaluation's owner has credentials for, wrapped for the

--- a/actionagent/test/mcp_tool_dispatcher_test.rb
+++ b/actionagent/test/mcp_tool_dispatcher_test.rb
@@ -94,6 +94,57 @@ class MCPToolDispatcherTest < ActiveSupport::TestCase
     assert_empty dispatcher.tool_definitions
   end
 
+  # #425: contributing nothing keeps the run alive, but a silent [] is
+  # indistinguishable from a server that serves no tools. The agent then runs
+  # tool-less and the model fabricates, while the run reports a plausible score.
+  test "a failed tools/list records why, naming the server and its url" do
+    dispatcher = dispatcher_with_client(StubClient.new(raises: "401 Unauthorized"))
+    dispatcher.tool_definitions
+
+    assert_equal %w[records], dispatcher.discovery_errors.keys
+    error = dispatcher.discovery_errors["records"]
+    assert_includes error, "records"
+    assert_includes error, "https://host.example/mcp/records"
+    assert_includes error, "401 Unauthorized"
+  end
+
+  test "a server that answers records no discovery error" do
+    dispatcher = dispatcher_with_client(StubClient.new)
+    dispatcher.tool_definitions
+
+    assert_empty dispatcher.discovery_errors
+    assert_not dispatcher.all_servers_failed?
+  end
+
+  test "every declared server failing is distinguishable from having no tools" do
+    dispatcher = dispatcher_with_client(StubClient.new(raises: "unreachable"))
+    dispatcher.tool_definitions
+
+    assert dispatcher.all_servers_failed?
+  end
+
+  # An agent naming no server has nothing to fail: its tool-less execution is
+  # the configured behaviour, not a transport problem.
+  test "an agent with no declared servers has not failed discovery" do
+    dispatcher = ActionAgent::MCPToolDispatcher.new(agent_with([]))
+    dispatcher.tool_definitions
+
+    assert_empty dispatcher.discovery_errors
+    assert_not dispatcher.all_servers_failed?
+  end
+
+  test "discovery errors from an earlier call do not leak into a later one" do
+    dispatcher = dispatcher_with_client(StubClient.new(raises: "unreachable"))
+    dispatcher.tool_definitions
+    assert dispatcher.all_servers_failed?
+
+    dispatcher.instance_variable_get(:@clients)["records"] = StubClient.new
+    dispatcher.tool_definitions
+
+    assert_empty dispatcher.discovery_errors
+    assert_not dispatcher.all_servers_failed?
+  end
+
   # A stateless server answers the initialize handshake with no Mcp-Session-Id,
   # and its notification body is a bare `null` — which JSON.parse returns as nil
   # rather than a hash.

--- a/actionagent/test/scenario_evaluation_runner_test.rb
+++ b/actionagent/test/scenario_evaluation_runner_test.rb
@@ -247,4 +247,50 @@ class ActionAgentScenarioEvaluationRunnerTest < ActiveSupport::TestCase
     assert_match(/No scenarios selected/, run.error_message)
     assert_equal [ run.id ], evaluation.evaluation_runs.ids
   end
+
+  # #425: a run whose MCP servers all failed discovery scored an agent that had
+  # no tools to call. Without this the only evidence was a logger.warn, and the
+  # report recommended prompt changes for a transport failure.
+  test "a run whose every MCP server failed discovery says so on the run" do
+    evaluation = build_suite(mcp_servers: %w[records])
+
+    with_unreachable_mcp_server do
+      evaluation.run!(models: [ "mock/alpha" ])
+    end
+
+    run = evaluation.evaluation_runs.order(:created_at).last
+    assert_equal "complete", run.status
+    assert_match(/Every MCP server this agent declares failed tool discovery/, run.error_message)
+    assert_match(/records/, run.error_message)
+    assert_match(/401 Unauthorized/, run.error_message)
+  end
+
+  test "a run whose servers answer records no discovery warning" do
+    evaluation = build_suite
+
+    evaluation.run!(models: [ "mock/alpha" ])
+
+    run = evaluation.evaluation_runs.order(:created_at).last
+    assert_equal "complete", run.status
+    assert_nil run.error_message
+  end
+
+  # Registers a catalog server the agent declares, whose tools/list refuses.
+  def with_unreachable_mcp_server
+    original = ActionAgent.mcp_catalog
+    ActionAgent.mcp_catalog = [
+      { key: "records", name: "Records", description: "Record lookups.",
+        transport: "http", url: "https://host.example/mcp/records",
+        tool_hints: %w[find_records] }
+    ]
+
+    refuser = Class.new do
+      def list_tools = raise(ActionAgent::MCPClient::Error, "401 Unauthorized")
+      def call_tool(_name, _arguments) = raise(ActionAgent::MCPClient::Error, "401 Unauthorized")
+    end.new
+
+    ActionAgent::MCPClient.stub(:new, refuser) { yield }
+  ensure
+    ActionAgent.mcp_catalog = original
+  end
 end


### PR DESCRIPTION
Closes #425.

`MCPToolDispatcher#tool_definitions` rescued a failed `tools/list` to `[]` and logged a warning, so **a server that 401s and a server that legitimately serves no tools were indistinguishable**. The agent then ran tool-less, the model fabricated an answer, and the run reported a plausible low score.

#425 records that costing several hours to diagnose, because the report offered "improve the instructions" recommendations for what was a transport failure. The only evidence was two `logger.warn` lines.

### What changed

Contributing nothing still keeps the run alive — that part was deliberate and is unchanged. What was missing is the *reason*:

- **`discovery_errors`** — why each declared server contributed no tools, naming the server, its URL and the underlying error:
  > `Cannot load tools from MCP server 'records' (https://host.example/mcp/records): 401 Unauthorized. Check its URL, transport and credentials.`
- **`all_servers_failed?`** — true when every declared HTTP server failed discovery. That is the case where a tool-backed scenario cannot produce a meaningful score, so a caller can fail loudly instead of grading an invented answer.

Errors reset per `tool_definitions` call, so a transient failure does not leak into a later run. An agent declaring no servers is not "failed" — its tool-less execution is the configured behaviour.

### Relationship to #421

This takes the approach from the unmerged #421 (`MCPToolBinding`'s `@discovery_errors`), narrowed to the dispatcher on current `main`. #421 is `CONFLICTING/DIRTY` and 54 commits behind, and #420 already solved execution a different way — so rebasing it wholesale was not worth it, while this idea was.

### Tests

5 new tests, all verified to fail without the change (`NoMethodError: undefined method 'discovery_errors'`).

- `actionagent/test`: **345 runs, 0 failures** (was 340)
- `test/evals`: **115 runs, 0 failures**
- RuboCop clean

### Follow-up

Surfacing these in the evaluation report is what turns "improve the instructions" back into "records returned 401". The scoring-side counterpart — that a fabricated answer raises no fault at all, so the judge is never asked for a tool — is #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01He34kWksjpqPPDpCCqJq2C

---

## Update — second commit

`093f8b4b` makes something actually read the recorded errors, and fixes a related understatement:

**The run now says when discovery failed.** A run whose declared MCP servers could not be reached scored an agent with no tools to call — the model answered from its own weights, so the scores are real but meaningless. `error_message` now carries that, naming each server and its error, and distinguishes *every* server failing from *some*. The column is already rendered by the evaluations API (`:362`), so it reaches the UI without new plumbing.

**The diagnosis roster was understated.** `tool_roster` listed only `AgentToolbox` definitions, so an agent whose tools come from MCP servers was diagnosed against a roster those tools were missing from — `Diagnosis` would report *"none of the available tools covers this task"* while naming an incomplete list. It now includes the dispatcher's discovered tools, matching what `AgentExecutionService#tool_schemas` offers the provider.

**Tests:** `actionagent/test` **347 runs, 0 failures** (main: 340). All new tests verified to fail without their implementation. RuboCop clean.