### PR TITLE
Stop nil VCR filters flaking replays, and spell the MCP plural

### DIFF
--- a/lib/active_agent/railtie.rb
+++ b/lib/active_agent/railtie.rb
@@ -114,6 +114,16 @@ module ActiveAgent
     initializer "active_agent.inflections" do
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.acronym "AI"
+
+        # "MCP" alone does not give the plural: an acronym only matches the
+        # whole word, so `mcps` still camelizes to `Mcps`, and a constant
+        # spelled `MCPs` underscores back to `mc_ps` — a name that round-trips
+        # to something no file is called.
+        #
+        # Registering the plural as its own acronym makes both directions
+        # agree: mcps <-> MCPs, alongside mcp_catalog <-> MCPCatalog.
+        inflect.acronym "MCP"
+        inflect.acronym "MCPs"
       end
     end
 

--- a/test/docs/actions/mcps_examples_test.rb
+++ b/test/docs/actions/mcps_examples_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module Docs
   module Actions
-    class McpsExamplesTest < ActiveSupport::TestCase
+    class MCPsExamplesTest < ActiveSupport::TestCase
       class QuickStartExample < ActiveSupport::TestCase
         # region quick_start_weather_agent
         class WeatherAgent < ActiveAgent::Base

--- a/test/docs/actions_examples_test.rb
+++ b/test/docs/actions_examples_test.rb
@@ -92,7 +92,7 @@ class ActionsExamplesTest < ActiveSupport::TestCase
     end
   end
 
-  class McpsExample < ActiveSupport::TestCase
+  class MCPsExample < ActiveSupport::TestCase
     # region mcps_research_agent
     class ResearchAgent < ApplicationAgent
       generate_with :anthropic, model: "claude-haiku-4-5"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -155,22 +155,38 @@ VCR.configure do |config|
     config.allow_http_connections_when_no_cassette = false
   end
 
-  config.filter_sensitive_data("ACCESS_TOKEN")     { ENV["OPEN_AI_ACCESS_TOKEN"] }
-  config.filter_sensitive_data("ORGANIZATION_ID")  { ENV["OPEN_AI_ORGANIZATION_ID"] }
-  config.filter_sensitive_data("PROJECT_ID")       { ENV["OPEN_AI_PROJECT_ID"] }
-  config.filter_sensitive_data("ACCESS_TOKEN")     { ENV["OPEN_ROUTER_ACCESS_TOKEN"] }
-  config.filter_sensitive_data("ACCESS_TOKEN")     { ENV["ANTHROPIC_ACCESS_TOKEN"] }
-  config.filter_sensitive_data("GITHUB_MCP_TOKEN") { ENV["GITHUB_MCP_TOKEN"] }
+  # A filter whose block returns nil or "" still registers, and VCR then tries
+  # to substitute an empty string throughout every request and response it
+  # handles. That surfaces far from here as an intermittent
+  # `undefined method 'each_key' for nil` inside WebMock while it builds a
+  # stubbed response, which reads as a flaky replay rather than a
+  # configuration problem.
+  #
+  # CI sets none of these variables — cassettes replay without credentials —
+  # so on CI every one of these blocks is nil. Registering a filter only when
+  # there is something to redact keeps replay deterministic there, and keeps
+  # the redaction for whoever records with real keys.
+  def config.filter_env(placeholder, name)
+    value = ENV[name]
+    return if value.nil? || value.empty?
+
+    filter_sensitive_data(placeholder) { value }
+  end
+
+  config.filter_env("ACCESS_TOKEN",     "OPEN_AI_ACCESS_TOKEN")
+  config.filter_env("ORGANIZATION_ID",  "OPEN_AI_ORGANIZATION_ID")
+  config.filter_env("PROJECT_ID",       "OPEN_AI_PROJECT_ID")
+  config.filter_env("ACCESS_TOKEN",     "OPEN_ROUTER_ACCESS_TOKEN")
+  config.filter_env("ACCESS_TOKEN",     "ANTHROPIC_ACCESS_TOKEN")
+  config.filter_env("GITHUB_MCP_TOKEN", "GITHUB_MCP_TOKEN")
 
   # Azure OpenAI credentials
-  config.filter_sensitive_data("AZURE_API_KEY")      { ENV["AZURE_OPENAI_API_KEY"] }
-  config.filter_sensitive_data("AZURE_RESOURCE")     { ENV["AZURE_OPENAI_RESOURCE"] }
-  config.filter_sensitive_data("AZURE_DEPLOYMENT")   { ENV["AZURE_OPENAI_DEPLOYMENT_ID"] }
+  config.filter_env("AZURE_API_KEY",    "AZURE_OPENAI_API_KEY")
+  config.filter_env("AZURE_RESOURCE",   "AZURE_OPENAI_RESOURCE")
+  config.filter_env("AZURE_DEPLOYMENT", "AZURE_OPENAI_DEPLOYMENT_ID")
 
   # Filter Azure resource name from URLs
-  if ENV["AZURE_OPENAI_RESOURCE"]
-    config.filter_sensitive_data("azure-resource") { ENV["AZURE_OPENAI_RESOURCE"] }
-  end
+  config.filter_env("azure-resource",   "AZURE_OPENAI_RESOURCE")
 end
 
 # Load fixtures from the engine


### PR DESCRIPTION
Two fixes to the same family of papercut. Both surfaced while diagnosing CI failures on #432, #434 and #435.

## 1. VCR filters registered against unset env vars

Every `filter_sensitive_data` block read an ENV var directly:

```ruby
config.filter_sensitive_data("ACCESS_TOKEN") { ENV["OPEN_AI_ACCESS_TOKEN"] }
```

**CI sets none of them** — cassettes replay without credentials — so on CI every block returns `nil`. VCR registers the filter anyway and then substitutes an empty string through every request and response it handles. That surfaces far from the cause as an intermittent:

```
NoMethodError: undefined method `each_key' for nil
  webmock-3.26.4/lib/webmock/util/hash_validator.rb:12:in `validate_keys'
  webmock/response.rb:80:in `options='
```

…while WebMock builds a stubbed response. It reads as a flaky cassette rather than a configuration problem. It failed `test (3.3, rails8)` on #435 (passed on re-run) and cost an investigation on #432 to rule out.

A `filter_env` helper now registers a filter only when the variable actually holds something. Replay is deterministic on CI; redaction still applies when recording with real keys.

This also generalises the one-off `if ENV["AZURE_OPENAI_RESOURCE"]` guard that already existed — the right instinct, applied to exactly one of ten filters.

## 2. The MCP plural did not inflect

An acronym only matches a whole word, so `inflect.acronym "MCP"` alone does not give the plural:

| input | before | after |
|---|---|---|
| `mcps`.camelize | `Mcps` | `MCPs` |
| `mcps_examples_test`.camelize | `McpsExamplesTest` | `MCPsExamplesTest` |
| `MCPsExamplesTest`.underscore | `mc_ps_examples_test` ❌ | `mcps_examples_test` ✅ |

That last row is the real bug: a constant spelled `MCPs` underscored back to a name no file has. Registering the plural as its own acronym makes both directions agree, and the two test classes spelling it `Mcps` are renamed to match.

**Deliberately unchanged:** `mcps:` stays lowercase as a prompt parameter, and `Mcp-Session-Id` keeps its spelling — that is what the MCP specification names the header. `ToolChoiceMcp` is an external OpenAI SDK constant.

The engine is unaffected by the new acronyms: `action_agent.inflections` already isolates every path under the engine root from host-registered acronyms, precisely so a host declaring `"API"` or `"MCP"` cannot break its constant lookups.

## Verification

- `actionagent/test`: **340 runs, 0 failures**
- The two renamed docs test files match their pre-change baseline **exactly** (15 runs, 9 errors both before and after — local missing-credential errors, since this machine has no `.env.test`)
- RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01He34kWksjpqPPDpCCqJq2C