### PR TITLE
chore(release): activeagent 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-09-11
+
+Releases `activeagent` 1.5.1. `actionagent` is unchanged and stays at 1.5.0.
+
+### Fixed
+
+- **A spec hash names its model rather than reaching the provider as an
+  inspected Hash.** `Evals::ModelSpec.parse_all` called `to_s` on each value,
+  so a Hash travelled as the model ID and the provider answered
+  `{"label" => "openrouter/openai/gpt-4o-mini", ...} is not a valid model ID`
+  — every scenario of the run failing before it reached the model. A caller
+  passing a plain string was unaffected, which is why a single run worked
+  while a whole suite failed. The path is reachable by design rather than by
+  misuse: a run persists its models as `specs.map(&:to_h)`, so re-running that
+  selection hands the hashes back. `parse_all` now reads a hash's `label`,
+  then its `model`, and leaves strings alone.
+
 ## [1.5.0] - 2026-09-10
 
 Releases `activeagent` 1.5.0 and `actionagent` 1.5.0 from one tag.

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end


### PR DESCRIPTION
Bumps `activeagent` to 1.5.1 and stamps the changelog. Tag `v1.5.1` after this merges to publish.

`actionagent` is unchanged since 1.5.0 and stays there — `release.yml` skips a version already on RubyGems, so it rebuilds and is passed over.

### Contents

https://github.com/activeagents/activeagent/pull/430 — `Evals::ModelSpec.parse_all` named a spec hash by its inspected form, so a dashboard-initiated scenario evaluation failed every scenario with HTTP 400 before reaching the model.

### Verification

`rake build_all` produces `activeagent-1.5.1.gem` carrying the fix, and `actionagent-1.5.0.gem` unchanged.

Against a host application, the same three-scenario run before and after the fix:

| | before | after |
|---|---|---|
| errors | 3 × HTTP 400 | 0 |
| tool calls | none | `list_filters`, `search_providers` |
| scores | 0.0 | 0.68 – 0.875 |