### PR TITLE
chore(release): activeagent and actionagent 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.1] - 2026-09-11
+## [1.5.2] - 2026-09-11
 
-Releases `activeagent` 1.5.1. `actionagent` is unchanged and stays at 1.5.0.
+Releases `activeagent` and `actionagent` 1.5.2 from one tag.
+
+**1.5.1 was never tagged.** Its version bump reached `main`, but three PRs
+that change `actionagent` merged alongside it, and that release deliberately
+held `actionagent` at 1.5.0 — publishing it would have shipped the fix below
+while leaving every dashboard change of this cycle unpublished, because
+`release.yml` skips a version already on RubyGems. 1.5.2 supersedes it and
+carries both gems. The 1.5.1 notes are kept below as the record of what that
+bump contained.
+
+### Added
+
+- **Schema-derived agent tools.** `ActiveAgent::SchemaTools` turns an
+  ActiveRecord model plus a declared boundary into a bounded, enumerable tool
+  roster — `find_*`, `count_*`, `get_*` — with `filterable` and `returns`
+  allowlists. An undeclared column is rejected rather than silently dropped:
+  ignoring an unknown filter answers a broader question than was asked while
+  still looking like success. Results are capped (25 default, 100 max) with a
+  truncation marker the model can see. (#435)
+
+- **Host tools reach the dashboard.** `ActionAgent.schema_tools` offers each
+  generated tool beside `AgentToolbox`'s built-ins: individually selectable in
+  the agent editor, dispatched by name at execution, and nameable in an
+  evaluation's `tools:` expectation. Previously a declared schema tool was
+  invisible — `definitions_for` returned nothing, the model received no
+  schemas and invented tool names in prose while the run scored 0.0 for what
+  looked like a model failure. (#435, closes #438)
+
+- **Tools are discovered, not declared twice.** Leave `schema_tools` unset and
+  every subclass under `schema_tools_path` (`app/agent_tools`) is offered.
+  Adding a tool is adding a file. Anonymous classes are excluded from
+  discovery: a runtime-built class cannot supersede itself, so it would
+  accumulate one per reload. (#435, refs #440)
+
+- **`scope_by_policy`** resolves a model's policy by name —
+  `Reservation` → `ReservationPolicy::Scope` — instead of hand-writing the
+  block. Opt-in, because silently scoping a class that declared none would
+  change what an existing tool returns; a missing policy raises at declaration
+  rather than quietly reading the whole table. (#435)
+
+- **A model's agent starts with that model's tools.** `ReservationAgent` is
+  seeded from `ReservationTools` on create. A default, never a restriction:
+  any agent may enable any tool, and an explicit selection — including a
+  deliberate empty one — is never overwritten. (#435)
+
+### Fixed
+
+- **MCP tool-discovery failures are reported instead of running tool-less and
+  silent.** `MCPToolDispatcher#tool_definitions` rescued a failed `tools/list`
+  to `[]`, so a server that 401s and one that legitimately serves no tools
+  were indistinguishable: the agent ran without tools, the model fabricated,
+  and the report offered prompt advice for what was a transport failure.
+  `discovery_errors` now names the server, its URL and the underlying error,
+  and `all_servers_failed?` lets a caller fail loudly rather than grade an
+  invented answer. (#434, closes #425)
+
+- **Nil VCR filters no longer flake replays**, and the MCP plural is spelled
+  correctly. (#436)
+
+## [1.5.1] - 2026-09-11 [UNRELEASED — superseded by 1.5.2]
+
+Bumped `activeagent` to 1.5.1 and held `actionagent` at 1.5.0. Never tagged;
+its contents ship in 1.5.2.
 
 ### Fixed
 

--- a/actionagent/lib/action_agent/version.rb
+++ b/actionagent/lib/action_agent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActionAgent
-  VERSION = "1.5.0"
+  VERSION = "1.5.2"
 end

--- a/lib/active_agent/version.rb
+++ b/lib/active_agent/version.rb
@@ -1,3 +1,3 @@
 module ActiveAgent
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end

--- a/test/schema_tools_test.rb
+++ b/test/schema_tools_test.rb
@@ -402,5 +402,4 @@ class SchemaToolsTest < ActiveSupport::TestCase
       Class.new(ActiveAgent::SchemaTools) { scope_by_policy }
     end
   end
-
 end


### PR DESCRIPTION
Bumps **both** gems to 1.5.2 and stamps the changelog. Tag `v1.5.2` after this merges to publish.

## Why 1.5.2 and not 1.5.1

#437 bumped `activeagent` to 1.5.1 and deliberately held `actionagent` at 1.5.0, which was correct for its own contents (#430, a `lib/` fix). But #434, #435 and #436 merged alongside it, and **two of those change `actionagent`**.

`v1.5.1` was never tagged. Had it been, `release.yml` would have skipped `actionagent` as already on RubyGems and published a release whose entire dashboard half — schema tools, the registration seam, MCP discovery errors — stayed invisible.

The 1.5.1 heading is kept in the changelog marked superseded rather than deleted; it is the record of what that bump contained.

## Contents

| PR | What |
|---|---|
| #435 | Schema-derived agent tools, the `AgentToolbox`/editor registration seam (closes #438), directory discovery and `scope_by_policy` (refs #440) |
| #434 | MCP tool-discovery failures reported instead of running tool-less and silent (closes #425) |
| #436 | Nil VCR filters no longer flake replays; MCP plural spelling |
| #430 | `Evals::ModelSpec.parse_all` names a spec hash's model rather than stringifying it (carried from the untagged 1.5.1) |

## Verification

`rake build_all` produces `activeagent-1.5.2.gem` and `actionagent-1.5.2.gem`. Checked inside both archives rather than trusting the build output:

- `activeagent` — `lib/active_agent/schema_tools.rb` present, `scope_by_policy` in it
- `actionagent` — `discovered_schema_tools` in `lib/action_agent.rb`, `discovery_errors` in `mcp_tool_dispatcher.rb`, and the **rebuilt** `app/assets/builds/action_agent.js` (the dashboard ships a precompiled bundle, so a stale one would silently omit the selectable tool cards)

Installed `activeagent-1.5.2` into a clean `GEM_HOME` and loaded `SchemaTools` from the installed copy.

Against a host application on both built gems:

```
activeagent=1.5.2 actionagent=1.5.2
discovered=["MilestoneTools", "TaskTools", "TicketTools"]   # no config.schema_tools declared
available_tools=22                                          # 13 built-ins + 9 generated
call={:count=>6}                                            # real data, through the host's Pundit scope
```

Its suite is green on the built gems.

## Publishing

`rake build_all` prints the order it needs: **`activeagent` before `actionagent`**, which depends on it.