### PR TITLE
fix(evals): re-run a persisted model selection under the provider it ran under

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A persisted model selection re-runs under the provider it ran under.**
+  `Evals::ModelSpec.parse_all` re-parsed a round-tripped spec from its label,
+  so `anthropic/claude-sonnet-4.5` run through OpenRouter came back as
+  Anthropic's own `claude-sonnet-4.5` as soon as that provider's gem was
+  installed — and the re-run failed for want of an Anthropic credential. A
+  hash naming both `provider` and `model` is now rebuilt as it was; a bare
+  label is still parsed. The dashboard's "re-run" of a saved selection is
+  the path this fixes.
+
 ## [1.5.2] - 2026-09-11
 
 Releases `activeagent` and `actionagent` 1.5.2 from one tag.

--- a/lib/active_agent/evals/model_spec.rb
+++ b/lib/active_agent/evals/model_spec.rb
@@ -46,22 +46,38 @@ module ActiveAgent
       # duplicates by label.
       def self.parse_all(values, **options)
         values = values.to_s.split(",") unless values.is_a?(Array)
-        values.map { |value| coerce(value) }.reject(&:blank?).uniq.map { |value| parse(value, **options) }
+        values.filter_map { |value| from_value(value, **options) }.uniq(&:label)
       end
 
-      # The label of one requested model. A caller that round-trips a spec —
-      # the dashboard persists `specs.map(&:to_h)` and hands it back on a
-      # re-run — sends a Hash, whose `to_s` is the inspected Hash and reaches
-      # the provider as the model ID: `{"label" => "openrouter/gpt-4o-mini",
-      # ...} is not a valid model ID`.
+      # One requested model, from the text a user typed or from a spec handed
+      # back whole. The dashboard persists `specs.map(&:to_h)` and returns it on
+      # a re-run, so a value may be a Hash: one that names both `provider` and
+      # `model` is rebuilt exactly as it ran, because re-parsing its label
+      # would route a vendor-prefixed model the wrong way —
+      # `"anthropic/claude-sonnet-4.5"` run through OpenRouter came back as
+      # Anthropic's own `claude-sonnet-4.5` the moment that provider was
+      # installed. A Hash naming only a label or a model is parsed from that
+      # text; anything naming nothing is dropped.
       #
-      # @return [String, nil] nil when the value names no model
-      def self.coerce(value)
-        return value.to_h.stringify_keys.values_at("label", "model").compact.first.to_s.strip if value.respond_to?(:to_h) && !value.is_a?(String)
+      # @return [ModelSpec, nil]
+      def self.from_value(value, **options)
+        text =
+          if value.respond_to?(:to_h) && !value.is_a?(String)
+            hash = value.to_h.stringify_keys
+            if hash["provider"].present? && hash["model"].present?
+              return new(label: hash["label"].presence || hash["model"], provider: hash["provider"], model: hash["model"])
+            end
 
-        value.to_s.strip
+            hash.values_at("label", "model").compact.first.to_s.strip
+          else
+            value.to_s.strip
+          end
+
+        return nil if text.blank?
+
+        parse(text, **options)
       end
-      private_class_method :coerce
+      private_class_method :from_value
 
       # The provider a bare model name runs under. A rule whose provider the
       # caller does not offer is skipped, so an app without Ollama does not

--- a/test/evals/model_spec_test.rb
+++ b/test/evals/model_spec_test.rb
@@ -8,6 +8,32 @@ class EvalsModelSpecTest < ActiveSupport::TestCase
     ActiveAgent::Evals::ModelSpec.parse(value, default_provider: "openai", **options)
   end
 
+  def test_a_persisted_spec_keeps_the_provider_it_ran_under
+    specs = ActiveAgent::Evals::ModelSpec.parse_all(
+      [ { "label" => "anthropic/claude-sonnet-4.5", "provider" => "openrouter", "model" => "anthropic/claude-sonnet-4.5" } ],
+      default_provider: "openrouter"
+    )
+
+    assert_equal [ [ "openrouter", "anthropic/claude-sonnet-4.5", "anthropic/claude-sonnet-4.5" ] ],
+      specs.map { |spec| [ spec.provider, spec.model, spec.label ] }
+  end
+
+  def test_a_persisted_spec_without_a_provider_is_parsed_from_its_label
+    specs = ActiveAgent::Evals::ModelSpec.parse_all([ { "label" => "anthropic/claude-sonnet-4.5" } ], default_provider: "openai")
+
+    assert_equal [ "anthropic" ], specs.map(&:provider)
+    assert_equal [ "claude-sonnet-4.5" ], specs.map(&:model)
+  end
+
+  def test_a_round_tripped_spec_is_not_duplicated_beside_its_own_label
+    spec = ActiveAgent::Evals::ModelSpec.new(label: "anthropic/claude-sonnet-4.5", provider: "openrouter", model: "anthropic/claude-sonnet-4.5")
+
+    specs = ActiveAgent::Evals::ModelSpec.parse_all([ spec.to_h, "anthropic/claude-sonnet-4.5" ], default_provider: "openrouter")
+
+    assert_equal 1, specs.size
+    assert_equal "openrouter", specs.first.provider
+  end
+
   def test_a_provider_prefix_names_the_provider
     spec = parse("anthropic/claude-sonnet-5")
 


### PR DESCRIPTION
`Evals::ModelSpec.parse_all` re-parsed a round-tripped spec from its label. The dashboard persists a run's selection as `specs.map(&:to_h)` and hands it back on re-run, so `{ label: "anthropic/claude-sonnet-4.5", provider: "openrouter", model: "anthropic/claude-sonnet-4.5" }` went back through `parse`, which reads a leading `anthropic/` as the provider whenever `anthropic` is in the candidate list — and `ScenarioEvaluationRunner` passes `Agent::PROVIDERS`, so it always is. The re-run then executed as Anthropic's own `claude-sonnet-4.5` and failed with "No credentials configured for provider 'anthropic'".

Found on a host app the moment the `anthropic` SDK was installed: the same saved selection that had run the day before could not be re-run from the dashboard.

## Change

A hash naming both `provider` and `model` is rebuilt exactly as it ran, keeping its label so cohorts still line up across runs. A hash naming only a label or a model is parsed from that text, as before; a value naming nothing is dropped; a persisted spec and its own bare label count as one candidate.

## Testing

- `test/evals/model_spec_test.rb`: three new cases (persisted spec keeps its provider; provider-less hash still parses from its label; a spec and its label are not duplicated).
- `bin/test test/evals/*_test.rb actionagent/test/scenario_evaluation_runner_test.rb actionagent/test/evaluations_api_test.rb` — 137 runs, 805 assertions, 0 failures.
- `bin/rubocop` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMSRnSxYS9mRx1hSjytB9Z
