### PR TITLE
feat(schema-tools): define a model's tools at runtime, registered per model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Schema tools can be defined at runtime.** `ActiveAgent::SchemaTools.define(Reservation,
+  filterable:, returns:, scope: | policy:)` builds the same bounded roster a
+  file under `app/agent_tools` would — same allowlists, same `call`, named
+  `ReservationTools` for logs — from a declaration held anywhere: a table, a
+  dashboard form, a test. The class is registered under its model and a
+  redefinition replaces the previous one, so a registry rebuilt on every
+  change holds one class per model; `undefine` drops it. The dashboard
+  discovers registry entries beside the files and lets a runtime definition
+  supersede a file for the same model. What is persisted, and where, stays the
+  host's decision; this is the seam a persisted declaration builds on. (#441)
+
+### Fixed
+
+- **A superseded runtime tool class is no longer offered twice.** Discovery
+  read every `SchemaTools` subclass out of `descendants`, where a class built
+  at runtime stays until it is collected, so rebuilding a model's tools
+  accumulated stale duplicates. Runtime-built classes are now read from the
+  registry only. (#441)
+
 ## [1.5.2] - 2026-09-11
 
 Releases `activeagent` and `actionagent` 1.5.2 from one tag.

--- a/actionagent/lib/action_agent.rb
+++ b/actionagent/lib/action_agent.rb
@@ -350,7 +350,10 @@ module ActionAgent
 
     # Directory scanned for SchemaTools subclasses when {#schema_tools} is
     # unset. Relative to the host's root. Set to nil to disable discovery and
-    # require an explicit declaration.
+    # require an explicit declaration. Classes built at runtime with
+    # +ActiveAgent::SchemaTools.define+ are discovered alongside the files
+    # whatever this is set to; only an explicit {#schema_tools} list excludes
+    # them.
     # @return [String, nil]
     attr_accessor :schema_tools_path
 
@@ -550,14 +553,31 @@ module ActionAgent
       schema_tool_classes.flat_map(&:tool_names).map(&:to_s)
     end
 
-    # SchemaTools subclasses defined under {#schema_tools_path}.
+    # SchemaTools classes on offer when {#schema_tools} is unset: the files
+    # under {#schema_tools_path}, and every runtime definition in
+    # +ActiveAgent::SchemaTools.registry+.
     #
     # The files are loaded before reading +descendants+: in development nothing
     # has referenced those constants yet, so the list would otherwise be empty
     # at boot and fill in only once something happened to touch them.
+    # Runtime-built classes are read from the registry, never from
+    # +descendants+, where every class ever built stays until collected and a
+    # superseded definition would be offered beside its replacement. A runtime
+    # definition for a model also supersedes a file for that model: it is the
+    # more recent intent.
     # @return [Array<Class>]
     def discovered_schema_tools
-      return [] if @schema_tools_path.blank? || !defined?(ActiveAgent::SchemaTools)
+      return [] unless defined?(ActiveAgent::SchemaTools)
+
+      from_registry = ActiveAgent::SchemaTools.respond_to?(:registry) ? ActiveAgent::SchemaTools.registry.values : []
+      (from_registry + file_defined_schema_tools).uniq { |klass| klass.model.name }
+    end
+
+    # The named SchemaTools subclasses under {#schema_tools_path}; none when
+    # the path is unset or the directory does not exist.
+    # @return [Array<Class>]
+    def file_defined_schema_tools
+      return [] if @schema_tools_path.blank?
       return [] unless defined?(Rails) && Rails.respond_to?(:root) && Rails.root
 
       root = Rails.root.join(@schema_tools_path)
@@ -569,7 +589,11 @@ module ActionAgent
         warn "[ActionAgent] could not load #{path}: #{e.class} - #{e.message}"
       end
 
-      ActiveAgent::SchemaTools.descendants.select { |klass| klass.name.present? }
+      ActiveAgent::SchemaTools.descendants.select { |klass| klass.name.present? && !runtime_schema_tools?(klass) }
+    end
+
+    def runtime_schema_tools?(klass)
+      klass.respond_to?(:runtime?) && klass.runtime?
     end
 
     # The schema tool class that generated +name+, or nil.

--- a/actionagent/test/schema_tools_registration_test.rb
+++ b/actionagent/test/schema_tools_registration_test.rb
@@ -45,6 +45,66 @@ class SchemaToolsRegistrationTest < ActiveSupport::TestCase
     assert_not_includes ActionAgent.schema_tool_classes, anonymous
   end
 
+  test "a runtime definition is discovered once, and a redefinition supersedes it" do
+    ActionAgent.schema_tools = nil
+    defined = ActiveAgent::SchemaTools.define(Post, filterable: %i[published], returns: %i[id title])
+
+    assert_includes ActionAgent.schema_tool_classes, defined
+    assert_equal 1, ActionAgent.schema_tool_classes.count { |klass| klass.model.name == "Post" }
+
+    again = ActiveAgent::SchemaTools.define(Post, filterable: %i[published], returns: %i[id])
+
+    assert_includes ActionAgent.schema_tool_classes, again
+    assert_not_includes ActionAgent.schema_tool_classes, defined, "a superseded class must not be offered beside its replacement"
+    assert_equal 1, ActionAgent.schema_tool_classes.count { |klass| klass.model.name == "Post" }
+    assert_equal again.tool_names, ActionAgent::Agent.new(name: "PostAgent").tap(&:valid?).tools
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+  end
+
+  test "a runtime definition supersedes a file-defined class for the same model" do
+    ActionAgent.schema_tools = nil
+    previous_path = ActionAgent.schema_tools_path
+    # File discovery scans descendants only when the directory exists; the
+    # dummy app has none, so point discovery at an empty one for this test.
+    ActionAgent.schema_tools_path = Dir.mktmpdir
+    file_defined = Class.new(ActiveAgent::SchemaTools) { model Post; returns :id }
+    file_defined.define_singleton_method(:name) { "FileBackedPostTools" }
+    assert_includes ActionAgent.schema_tool_classes, file_defined
+
+    runtime = ActiveAgent::SchemaTools.define(Post, returns: %i[id title])
+
+    assert_includes ActionAgent.schema_tool_classes, runtime
+    assert_not_includes ActionAgent.schema_tool_classes, file_defined
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+    ActionAgent.schema_tools_path = previous_path
+  end
+
+  test "runtime definitions are offered even when file discovery is switched off" do
+    ActionAgent.schema_tools = nil
+    previous_path = ActionAgent.schema_tools_path
+    ActionAgent.schema_tools_path = nil
+    runtime = ActiveAgent::SchemaTools.define(Post, returns: %i[id])
+
+    assert_equal [ runtime ], ActionAgent.schema_tool_classes
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+    ActionAgent.schema_tools_path = previous_path
+  end
+
+  test "an explicit declaration excludes the registry unless it names it" do
+    runtime = ActiveAgent::SchemaTools.define(Post, returns: %i[id])
+
+    ActionAgent.schema_tools = [ FakeTools ]
+    assert_equal [ FakeTools ], ActionAgent.schema_tool_classes
+
+    ActionAgent.schema_tools = [ FakeTools, runtime ]
+    assert_equal [ FakeTools, runtime ], ActionAgent.schema_tool_classes
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+  end
+
   test "discovery is disabled by a blank path" do
     ActionAgent.schema_tools = nil
     previous_path = ActionAgent.schema_tools_path

--- a/docs/actions/tools.md
+++ b/docs/actions/tools.md
@@ -156,6 +156,24 @@ class TriageAgent < ApplicationAgent
 end
 ```
 
+## Defining Schema Tools at Runtime
+
+A schema tools class does not have to be a file. `ActiveAgent::SchemaTools.define` builds the same bounded roster from a declaration held anywhere — a table your dashboard edits, a configuration object, a test:
+
+```ruby
+tools = ActiveAgent::SchemaTools.define(Reservation,
+  filterable: %i[status guest_id],
+  returns: %i[id status guest_id arrives_on],
+  policy: true)                     # ReservationPolicy::Scope, as scope_by_policy would
+
+tools.name        # => "ReservationTools"
+tools.tool_names  # => ["find_reservations", "count_reservations", "get_reservation"]
+```
+
+The class is registered under its model, and defining the same model again **replaces** the earlier class rather than adding one, so a registry that is rebuilt on every change holds one class per model. `undefine(Reservation)` drops it. The [dashboard engine](/framework/dashboard) discovers registry entries alongside the files under `app/agent_tools`, and a runtime definition supersedes a file for the same model.
+
+The allowlist is the same judgement wherever the declaration lives: a definition that can be edited without a deploy deserves the same review a file would get, and nothing secret-shaped belongs in it.
+
 ## Related Documentation
 
 - [Delegation](/actions/delegation) - Expose another agent to your model as a tool

--- a/lib/active_agent/schema_tools.rb
+++ b/lib/active_agent/schema_tools.rb
@@ -168,6 +168,71 @@ module ActiveAgent
         @scope = block
       end
 
+      # Runtime-defined tool classes, keyed by model name. A definition built
+      # by {.define} replaces the previous one for its model, so a registry
+      # that is rebuilt on every change — from a table, from a dashboard
+      # edit — holds one class per model rather than one per rebuild.
+      #
+      # @return [Hash{String => Class}]
+      def registry
+        @registry ||= {}
+      end
+
+      # Builds a tool class from a declaration rather than from a file:
+      #
+      #   ActiveAgent::SchemaTools.define(Reservation,
+      #     filterable: %i[status guest_id],
+      #     returns: %i[id status guest_id arrives_on],
+      #     policy: true)   # ReservationPolicy::Scope, as scope_by_policy would
+      #
+      # The class behaves exactly as a file-defined one — same roster, same
+      # allowlists, same +call+ — and is named "<Model>Tools" for logs and
+      # telemetry. It is marked runtime-built so discovery does not read it
+      # back out of +descendants+ (where every class ever built stays until
+      # collected), and registered under its model, replacing whatever the
+      # registry held: that is what keeps a rebuild from accumulating classes
+      # (#441). +scope:+ takes a lambda or proc receiving the actor; +policy:+
+      # resolves the model's policy by name; neither means unscoped, as for a
+      # file-defined class.
+      #
+      # @param model [Class] an ActiveRecord class
+      # @param filterable [Array<Symbol, String>]
+      # @param returns [Array<Symbol, String>]
+      # @param scope [Proc, nil]
+      # @param policy [Boolean, Class] true for the conventional policy, or the policy class
+      # @param name [String, nil] the class name, "<Model>Tools" by default
+      # @return [Class]
+      def define(model, filterable: [], returns: [], scope: nil, policy: false, name: nil)
+        klass = Class.new(self)
+        klass.instance_variable_set(:@runtime, true)
+        class_name = name || "#{model.name}Tools"
+        klass.define_singleton_method(:name) { class_name }
+        klass.model(model)
+        klass.filterable(*filterable) if filterable.present?
+        klass.returns(*returns) if returns.present?
+        klass.scope_by_policy(policy == true ? nil : policy) if policy
+        klass.scope(&scope) if scope
+
+        registry[model.name] = klass
+      end
+
+      # Drops the runtime definition for +model+; discovery stops offering it.
+      #
+      # @param model [Class, String]
+      # @return [Class, nil] the class that was registered
+      def undefine(model)
+        registry.delete(model.respond_to?(:name) ? model.name : model.to_s)
+      end
+
+      # Whether this class was built by {.define} rather than loaded from a
+      # file. Discovery reads runtime classes from {.registry}, never from
+      # +descendants+, so a superseded one is not offered twice.
+      #
+      # @return [Boolean]
+      def runtime?
+        @runtime == true
+      end
+
       # The full, fixed tool roster in provider function-calling format.
       #
       # @return [Array<Hash>] tool definitions with :name, :description, :parameters

--- a/test/schema_tools_test.rb
+++ b/test/schema_tools_test.rb
@@ -381,6 +381,57 @@ class SchemaToolsTest < ActiveSupport::TestCase
     scope_by_policy FakePolicyScope
   end
 
+  # --- Runtime definitions ------------------------------------------------
+
+  test "define builds a named, registered tool class from a declaration" do
+    tools = ActiveAgent::SchemaTools.define(
+      Post, filterable: %i[published], returns: %i[id title],
+      scope: ->(actor) { actor ? actor.posts : Post.none }
+    )
+
+    assert_equal "PostTools", tools.name
+    assert tools.runtime?
+    assert_not UserTools.runtime?
+    assert_equal %w[find_posts count_posts get_post], tools.tool_names
+    assert_equal 1, tools.call("count_posts", actor: @alice)[:count]
+    assert_equal 0, tools.call("count_posts", actor: nil)[:count]
+    assert_same tools, ActiveAgent::SchemaTools.registry["Post"]
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+  end
+
+  test "redefining a model's tools replaces the previous class instead of adding one" do
+    first = ActiveAgent::SchemaTools.define(Post, filterable: %i[published], returns: %i[id])
+    second = ActiveAgent::SchemaTools.define(Post, filterable: %i[published], returns: %i[id title])
+
+    assert_same second, ActiveAgent::SchemaTools.registry["Post"]
+    assert_equal 1, ActiveAgent::SchemaTools.registry.count { |model_name, _| model_name == "Post" }
+    assert_equal %w[id title], second.returns.map(&:to_s)
+    assert first.runtime?, "a superseded class stays runtime-built, so discovery never reads it from descendants"
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+  end
+
+  test "define accepts a policy class and undefine drops the registration" do
+    tools = ActiveAgent::SchemaTools.define(Post, returns: %i[id], policy: ScopedByPolicyPost::FakePolicyScope)
+
+    assert_equal Post.count, tools.call("count_posts", actor: :someone)[:count]
+    assert_equal 0, tools.call("count_posts", actor: nil)[:count]
+
+    assert_same tools, ActiveAgent::SchemaTools.undefine(Post)
+    assert_nil ActiveAgent::SchemaTools.registry["Post"]
+    assert_nil ActiveAgent::SchemaTools.undefine("Post")
+  end
+
+  test "a runtime class enforces the same boundary as a file-defined one" do
+    tools = ActiveAgent::SchemaTools.define(Post, filterable: %i[published], returns: %i[id title])
+
+    assert_match(/not a filterable attribute/, tools.call("find_posts", user_id: 1)[:error])
+    assert_equal %w[id title], tools.call("find_posts")[:results].first.keys.map(&:to_s)
+  ensure
+    ActiveAgent::SchemaTools.undefine(Post)
+  end
+
   test "scope_by_policy routes reads through the given policy scope" do
     assert_equal Post.count, ScopedByPolicyPost.call("count_posts", actor: :someone)[:count]
     assert_equal 0, ScopedByPolicyPost.call("count_posts", actor: nil)[:count]


### PR DESCRIPTION
Refs #441 — the "build the class on demand" half, with the leak it names closed. What is persisted, and where, is left to the host; this is the seam a persisted declaration builds on.

## Change

`ActiveAgent::SchemaTools.define(model, filterable:, returns:, scope: | policy:, name:)` builds a tool class from a declaration rather than a file:

```ruby
tools = ActiveAgent::SchemaTools.define(Reservation,
  filterable: %i[status guest_id], returns: %i[id status guest_id arrives_on], policy: true)
tools.name        # => "ReservationTools"
tools.tool_names  # => ["find_reservations", "count_reservations", "get_reservation"]
```

Same roster, same allowlists, same `call`, same boundary (an undeclared filter is still rejected, only declared columns are read back). The class is marked runtime-built and **registered under its model**; defining the same model again replaces the earlier class, so a registry rebuilt on every change holds one class per model. `undefine` drops it.

The issue's option 1 ("do not track anonymous subclasses") is not possible — `Class#subclasses` cannot be opted out of — so the engine's discovery stops reading runtime classes out of `descendants` at all and takes them from the registry instead. That is the measured leak (`descendants before=0 after=2`) closed at the point where it did harm: a superseded class is never offered beside its replacement. A runtime definition also supersedes a file for the same model (the more recent intent), and registry entries are offered even with file discovery switched off; only an explicit `config.schema_tools` list excludes them, as it excludes everything it does not name.

Option 3 (an instance-based `Definition` with no classes at all) is the cleaner long-term shape; this keeps the class-level DSL as the one implementation so the two paths cannot drift, at the cost of one class object per (model, definition), which the registry bounds.

## Testing

- `test/schema_tools_test.rb` (+4): define, replace, policy + undefine, the boundary on a runtime class.
- `actionagent/test/schema_tools_registration_test.rb` (+4): discovered once and superseded, supersedes a file for the same model, offered with file discovery off, excluded by an explicit list.
- `bin/test test/schema_tools_test.rb actionagent/test/schema_tools_registration_test.rb` — 59 runs, 205 assertions, 0 failures. Full suite locally: see the comment below.
- `bin/rubocop` clean on the changed files. Docs: a section in `docs/actions/tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMSRnSxYS9mRx1hSjytB9Z
