### PR TITLE
feat(delegation): a delegated run inherits its parent's caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A delegated run inherits its parent's caller.** `delegate_to` hands the
+  sub-agent the parent's `current_user` before its action runs, so its own
+  `before_action` callbacks and any scope its tools read through decide
+  against the same person. A parent authorized as one user no longer hands
+  its specialists an unattributed run — which a correctly written host scope
+  reads as "no access", a wrong answer wearing a right one's clothes. A
+  parent with no caller still delegates an unattributed run, never someone
+  else's.
+
 ### Fixed
 
 - **The caller can no longer be named by the model, or by the client.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A delegated run inherits its parent's caller.** `delegate_to` hands the
+  sub-agent the parent's `current_user` before its action runs, so its own
+  `before_action` callbacks and any scope its tools read through decide
+  against the same person. A parent authorized as one user no longer hands
+  its specialists an unattributed run — which a correctly written host scope
+  reads as "no access", a wrong answer wearing a right one's clothes. A
+  parent with no caller still delegates an unattributed run, never someone
+  else's.
 - **An agent knows who it is running for, so an authorization gem has
   something to decide against.** `ActiveAgent::Base#current_user` carries the
   caller, assigned by whatever authenticated the call

--- a/lib/active_agent/delegation/runner.rb
+++ b/lib/active_agent/delegation/runner.rb
@@ -117,6 +117,7 @@ module ActiveAgent
       def generate(arguments)
         agent = definition.resolved_agent_class.new
         agent.params = resolved_params(arguments)
+        inherit_actor(agent)
         agent.process(definition.action, **arguments)
 
         definition.backend.apply(agent)
@@ -124,6 +125,22 @@ module ActiveAgent
         inherit_trace_id(agent)
 
         agent.process_prompt
+      end
+
+      # A delegated generation runs on behalf of whoever the parent runs for.
+      # The sub-agent gets the parent's caller before its action runs, so its
+      # own before_action callbacks and any scope its tools read through decide
+      # against the same person — a parent authorized as one user must not
+      # hand its specialists an unattributed run, which a correctly written
+      # host scope reads as "no access". Hosts on an older framework, where an
+      # agent has no caller to carry, are left as they were.
+      #
+      # @param agent [ActiveAgent::Base]
+      # @return [void]
+      def inherit_actor(agent)
+        return unless owner.respond_to?(:current_user) && agent.respond_to?(:current_user=)
+
+        agent.current_user = owner.current_user
       end
 
       # A delegated generation is part of its parent's work, so it carries the

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -164,4 +164,47 @@ class AuthorizationTest < ActiveSupport::TestCase
     assert_equal "an unauthenticated caller is not allowed to call `delete_ticket`",
       agent.tools_function.call(:delete_ticket, id: 7)[:error]
   end
+
+  # A parent authorized as one caller must hand its specialists the same
+  # caller: an unattributed delegated run reads, through any host scope, as
+  # "no access", which is a wrong answer wearing a right one's clothes.
+  class SpecialistAgent < ActiveAgent::Base
+    generate_with :mock
+
+    SEEN = []
+
+    before_action { SEEN << current_user&.name }
+
+    delegation :summarize, description: "Condense text" do
+      string :text, required: true
+    end
+
+    def summarize(text:)
+      prompt(message: text)
+    end
+  end
+
+  class OrchestratorAgent < ActiveAgent::Base
+    generate_with :mock
+
+    delegate_to SpecialistAgent
+  end
+
+  test "a delegated run inherits the parent's caller" do
+    SpecialistAgent::SEEN.clear
+    orchestrator = OrchestratorAgent.new
+    orchestrator.current_user = Caller.new("alice")
+
+    orchestrator.perform_delegation(:summarize, text: "The order shipped on Monday.")
+
+    assert_equal [ "alice" ], SpecialistAgent::SEEN
+  end
+
+  test "a parent with no caller delegates an unattributed run, never someone else's" do
+    SpecialistAgent::SEEN.clear
+
+    OrchestratorAgent.new.perform_delegation(:summarize, text: "The order shipped.")
+
+    assert_equal [ nil ], SpecialistAgent::SEEN
+  end
 end


### PR DESCRIPTION
Stacked on #443 (the caller seam); retarget to `main` once that merges.

`Delegation::Runner#generate` built the sub-agent with the parent's params and trace id but not its caller, so `SupportHubAgent.as(user)` delegating to `TicketAgent` ran the specialist unattributed — and a host scope written correctly against Pundit answered "no tickets" to a user with plenty. Found in a host app that had to forward the user through `params:` by hand to work around it.

## Change

The sub-agent gets the parent's `current_user` before its action runs (`inherit_actor`), so its own `before_action` callbacks and any `SchemaTools` scope its tools read through decide against the same person. A parent with no caller still delegates an unattributed run — never someone else's. Hosts on a framework without the seam are left as they were (the assignment is guarded on `respond_to?`).

## Testing

- `test/authorization_test.rb` (+2): a delegated run sees the parent's caller; a parent with no caller delegates `nil`.
- `bin/test test/authorization_test.rb test/delegation_test.rb` — 12 runs, 20 assertions, 0 failures.
- `bin/rubocop` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMSRnSxYS9mRx1hSjytB9Z
